### PR TITLE
Improving Camera Conversion

### DIFF
--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -331,13 +331,21 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
         // Publish the MLNMapView's "raw" camera state to the MapView camera binding.
         // This path only executes when the map view diverges from the parent state, so this is a "matter of fact"
         // state propagation.
+        
+        // Determine camera pitch range based on current MapView settings
+        let pitchRange: CameraPitchRange
+        if mapView.minimumPitch == 0 && mapView.maximumPitch > 59.9 {
+            pitchRange = .free
+        } else if mapView.minimumPitch == mapView.maximumPitch {
+            pitchRange = .fixed(mapView.minimumPitch)
+        } else {
+            pitchRange = .freeWithinRange(minimum: mapView.minimumPitch, maximum: mapView.maximumPitch)
+        }
+        
         let newCamera: MapViewCamera = .center(mapView.centerCoordinate,
                                                zoom: mapView.zoomLevel,
                                                pitch: mapView.camera.pitch,
-                                               pitchRange: .freeWithinRange(
-                                                   minimum: mapView.minimumPitch,
-                                                   maximum: mapView.maximumPitch
-                                               ),
+                                               pitchRange: pitchRange,
                                                direction: mapView.direction,
                                                reason: CameraChangeReason(reason))
         snapshotCamera = newCamera

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -331,17 +331,16 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
         // Publish the MLNMapView's "raw" camera state to the MapView camera binding.
         // This path only executes when the map view diverges from the parent state, so this is a "matter of fact"
         // state propagation.
-        
+
         // Determine camera pitch range based on current MapView settings
-        let pitchRange: CameraPitchRange
-        if mapView.minimumPitch == 0 && mapView.maximumPitch > 59.9 {
-            pitchRange = .free
+        let pitchRange: CameraPitchRange = if mapView.minimumPitch == 0 && mapView.maximumPitch > 59.9 {
+            .free
         } else if mapView.minimumPitch == mapView.maximumPitch {
-            pitchRange = .fixed(mapView.minimumPitch)
+            .fixed(mapView.minimumPitch)
         } else {
-            pitchRange = .freeWithinRange(minimum: mapView.minimumPitch, maximum: mapView.maximumPitch)
+            .freeWithinRange(minimum: mapView.minimumPitch, maximum: mapView.maximumPitch)
         }
-        
+
         let newCamera: MapViewCamera = .center(mapView.centerCoordinate,
                                                zoom: mapView.zoomLevel,
                                                pitch: mapView.camera.pitch,


### PR DESCRIPTION
# Issue/Motivation

I noticed that in certain situations, even though my camera was setup as pitchRange = .free, it kept switching to .freeWithinRange(0, 59.9999999). When back converting the MLNMapView camera we were missing determining the pitch range based on our enum: the camera would always be set to .freeWithinRange instead of trying to go for .free or .fixed too if applicable.

## Tasklist

- [N/A] Include tests (if applicable) and examples (new or edits)
- [N/A] If there are any visual changes as a result, include before/after screenshots and/or videos
- [N/A] Add #fixes with the issue number that this PR addresses
- [N/A] Update any documentation for affected APIs
- [N/A] Update the CHANGELOG
