### PR TITLE
Upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.3.0 - 2024-10-14
+
+### Changed
+
+This release upgrades Swift tooling for Swift 5.10.
+
 ## Version 0.2.0 - 2024-10-07
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "eb291c5878b6a430da1ca556743fd0109f383ad28c681401e0b93a12b03ca77d",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stadiamaps/maplibre-swift-macros.git",
       "state" : {
-        "revision" : "236215c13bff962009e0f0257d6d8349be33442f",
-        "version" : "0.0.4"
+        "revision" : "9e27e62dff7fd727aebd0a7c8aa74e7635a5583e",
+        "version" : "0.0.5"
       }
     },
     {
@@ -41,10 +42,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "eb291c5878b6a430da1ca556743fd0109f383ad28c681401e0b93a12b03ca77d",
+  "originHash" : "ef57277e00807f229851c4bb0692df5652d1ca801f92fa003373a73212ebd3bf",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "abe762f1e19e03a4c6943d2aad92c219da384b29",
-        "version" : "6.5.4"
+        "revision" : "f23db791d7b6f0329e3c6788d8e4152c24c52b6b",
+        "version" : "6.7.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.4.0"),
-        .package(url: "https://github.com/stadiamaps/maplibre-swift-macros.git", from: "0.0.3"),
+        .package(url: "https://github.com/stadiamaps/maplibre-swift-macros.git", from: "0.0.5"),
         // Testing
         .package(url: "https://github.com/Kolos65/Mockable.git", exact: "0.0.10"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.2"),

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.4.0"),
+        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.7.1"),
         .package(url: "https://github.com/stadiamaps/maplibre-swift-macros.git", from: "0.0.5"),
         // Testing
         .package(url: "https://github.com/Kolos65/Mockable.git", exact: "0.0.10"),

--- a/Sources/MapLibreSwiftUI/Examples/Layers.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Layers.swift
@@ -89,7 +89,7 @@ let clustered = ShapeSource(identifier: "points", options: [.clustered: true, .c
 }
 
 #Preview("Clustered Circles with Symbols") {
-    return MapView(styleURL: demoTilesURL, camera: .constant(MapViewCamera.center(
+    MapView(styleURL: demoTilesURL, camera: .constant(MapViewCamera.center(
         CLLocationCoordinate2D(latitude: 48.2082, longitude: 16.3719),
         zoom: 5,
         direction: 0

--- a/Sources/MapLibreSwiftUI/Examples/Layers.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Layers.swift
@@ -89,12 +89,11 @@ let clustered = ShapeSource(identifier: "points", options: [.clustered: true, .c
 }
 
 #Preview("Clustered Circles with Symbols") {
-    @State var camera = MapViewCamera.center(
+    return MapView(styleURL: demoTilesURL, camera: .constant(MapViewCamera.center(
         CLLocationCoordinate2D(latitude: 48.2082, longitude: 16.3719),
         zoom: 5,
         direction: 0
-    )
-    return MapView(styleURL: demoTilesURL, camera: $camera) {
+    ))) {
         // Clusters pins when they would touch
 
         // Cluster == YES shows only those pins that are clustered, using .text


### PR DESCRIPTION
* Upgrade SwiftSyntax to 5.10 (via macros package, which [got a bump](https://github.com/stadiamaps/maplibre-swift-macros/commit/9e27e62dff7fd727aebd0a7c8aa74e7635a5583e)). I was getting an absurd number of SPM failures which seem to have gone away after upgrading to the 510.x series.
* Upgrade Swift tooling to 5.10 (SwiftSyntax is somewhat specific to Swift tooling); everyone should have this by now.
* Fix unrelated lint (new in Xcode 16; we don't actually need that `@State`, but in related news, iOS 17+ get a new `@Previewable` annotation which lets us simplify the examples that DO need state... we can switch next year)
* Upgrade MapLibre to the latest release ([CHANGELOG doesn't have anything that looks like it'd break anything](https://github.com/maplibre/maplibre-native/releases?q=ios&expanded=true); tested out the Ferrostar demo app and examples locally)