### PR TITLE
The location updates doesnt work if we set it in the update view 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.3.1 - 2024-10-17
+
+### Fixed
+
+- Fixed the location manager being nil after SwiftUI view update.
+
 ## Version 0.3.0 - 2024-10-14
 
 ### Changed

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -106,6 +106,7 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
                                              camera: camera,
                                              animated: isStyleLoaded)
         }
+        uiViewController.mapView.locationManager = locationManager
     }
 
     @MainActor private func applyModifiers(_ mapViewController: T, runUnsafe: Bool) {

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -106,7 +106,6 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
                                              camera: camera,
                                              animated: isStyleLoaded)
         }
-        uiViewController.mapView.locationManager = locationManager
     }
 
     @MainActor private func applyModifiers(_ mapViewController: T, runUnsafe: Bool) {


### PR DESCRIPTION
# Issue/Motivation

The location updates doesnt work if we set it in the update view block better to keep it only in the create and assign it there once

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
- [ ] Update the CHANGELOG
