### PR TITLE
Fix missing Dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: macos-15
 
     steps:
-    - name: Install tools
-      run: brew install swiftformat
-      
     - name: Checkout maplibre-swiftui-dsl-playground
       uses: actions/checkout@v4
 
@@ -30,6 +27,7 @@ jobs:
         destination: [
           # TODO: Add more destinations
           'platform=iOS Simulator,name=iPhone 16,OS=18.1'
+          'platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.0'
         ]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,9 @@ jobs:
         ]
         destination: [
           # TODO: Add more destinations
-          'platform=iOS Simulator,name=iPhone 16,OS=18.1',
-          'platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.0'
+          'platform=iOS Simulator,name=iPhone 16,OS=18.1'
         ]
+    name: ${{ matrix.destination }}
 
     steps:
     - name: Install tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         ]
         destination: [
           # TODO: Add more destinations
-          'platform=iOS Simulator,name=iPhone 15,OS=17.5'
+          'platform=iOS Simulator,name=iPhone 16,OS=18.1'
         ]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   format-lint:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - name: Install tools
@@ -21,7 +21,7 @@ jobs:
       run: swiftformat . --lint
 
   test:
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         scheme: [
@@ -34,14 +34,15 @@ jobs:
 
     steps:
     - name: Install tools
-      run: brew install xcbeautify
+      run: brew update && brew upgrade xcbeautify
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.4'
+        xcode-version: latest-stable
 
     - name: Checkout maplibre-swiftui-dsl-playground
       uses: actions/checkout@v4
 
     - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}
       run: xcodebuild -scheme ${{ matrix.scheme }} test -skipMacroValidation -destination '${{ matrix.destination }}' | xcbeautify && exit ${PIPESTATUS[0]}
+      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         ]
         destination: [
           # TODO: Add more destinations
-          'platform=iOS Simulator,name=iPhone 16,OS=18.1'
+          'platform=iOS Simulator,name=iPhone 16,OS=18.1',
           'platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.0'
         ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixes failed builds when this packages is integrated in an App. InternalUtils package was missing a dependency to MapLibre
+
 ## Version 0.4.0 - 2024-11-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Version 0.4.1 - 2024-11-19
 
 ### Fixed
 

--- a/Package.swift
+++ b/Package.swift
@@ -54,9 +54,9 @@ let package = Package(
         ),
         .target(
             name: "InternalUtils",
-			dependencies: [
-				.product(name: "MapLibre", package: "maplibre-gl-native-distribution"),
-			],
+            dependencies: [
+                .product(name: "MapLibre", package: "maplibre-gl-native-distribution"),
+            ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,9 @@ let package = Package(
         ),
         .target(
             name: "InternalUtils",
+			dependencies: [
+				.product(name: "MapLibre", package: "maplibre-gl-native-distribution"),
+			],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
             ]

--- a/Sources/MapLibreSwiftUI/Extensions/CoreLocation/CLLocationCoordinate2D.swift
+++ b/Sources/MapLibreSwiftUI/Extensions/CoreLocation/CLLocationCoordinate2D.swift
@@ -2,7 +2,7 @@ import CoreLocation
 
 // TODO: We can delete chat about this. I'm not 100% on it, even though I want Hashable
 // on the MapCameraView (so we can let a user present a MapView with a designated camera from NavigationLink)
-extension CLLocationCoordinate2D: Hashable {
+extension CLLocationCoordinate2D: @retroactive Hashable {
     public static func == (lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
         lhs.latitude == rhs.latitude
             && lhs.longitude == rhs.longitude

--- a/Sources/MapLibreSwiftUI/Models/MapCamera/CameraState.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/CameraState.swift
@@ -65,7 +65,7 @@ extension CameraState: CustomDebugStringConvertible {
     }
 }
 
-extension MLNCoordinateBounds: Equatable, Hashable {
+extension MLNCoordinateBounds: @retroactive Equatable, @retroactive Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(ne)
         hasher.combine(sw)
@@ -76,7 +76,7 @@ extension MLNCoordinateBounds: Equatable, Hashable {
     }
 }
 
-extension UIEdgeInsets: Hashable {
+extension UIEdgeInsets: @retroactive Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(left)
         hasher.combine(right)


### PR DESCRIPTION
### Description

We encountered failing builds in our build pipeline after updating to the newest version. We are using Xcode Cloud and every build fails because Utilities.swift can't find MapLibre. I am able to reproduce this issue locally when I clean the build folder but not when building. Not sure why there is difference on Xcode Cloud.

### Tasks

- [x] ~~Include tests (if applicable) and examples (new or edits)~~
- [x] ~~If there are any visual changes as a result, include before/after screenshots and/or videos~~
- [x] ~~Add #fixes with the issue number that this PR addresses~~
- [x] ~~Update any documentation for affected APIs~~
- [x] Update the CHANGELOG
- [x] Add MapLibre as dependency of InternalUtils Package
- [x] Fix some warnings on the way.

### Infos for Reviewer

After adding MapLibre as a dependency to the InternalUtils package I was not able to reproduce this anymore.


Here is a screenshot from Xcode Cloud before my changes:

![Screenshot 2024-11-19 at 15 22 14](https://github.com/user-attachments/assets/89cbcaa4-ebc6-4805-b492-fcc18ae9b9c9)

And locally (before my changes):

![Screenshot 2024-11-19 at 15 28 20](https://github.com/user-attachments/assets/e8a07821-7d0d-4d09-8741-c412828e2b63)




