### PR TITLE
Default to nil for contentInset

### DIFF
--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -18,7 +18,7 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
     var onStyleLoaded: ((MLNStyle) -> Void)?
     var onViewPortChanged: ((MapViewPort) -> Void)?
 
-    var mapViewContentInset: UIEdgeInsets? = .zero
+    var mapViewContentInset: UIEdgeInsets?
 
     var unsafeMapViewControllerModifier: ((T) -> Void)?
 


### PR DESCRIPTION
# Issue/Motivation

When we set mapViewContentInset, this sets automaticallyAdjustsContentInset to false on line 113. The current default value for automaticallyAdjustsContentInset is .zero at the moment instead of nil, so automaticallyAdjustsContentInset is always false, even if a developer is not using our mapViewContentInset.

This PR changes the default to nil, so that automaticallyAdjustsContentInset isn't affected if a developer is not using mapViewContentInset.
