### PR TITLE
feat: integrates macro targets into swift package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,15 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        scheme: [MapLibreSwiftUI, MapLibreSwiftDSL]
+        scheme: [MapLibreSwiftUI-Package]
         destination: [
             # TODO: Add more destinations
             "platform=iOS Simulator,name=iPhone 16,OS=18.1",
+            # 'platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)',
+            "platform=iOS Simulator,name=iPad (10th generation),OS=16.4",
+            "platform=iOS Simulator,name=iPhone 15,OS=17.2",
           ]
-    name: test ${{ matrix.destination }}
+    name: ${{ matrix.destination }}
 
     steps:
       - name: Install tools
@@ -37,32 +40,6 @@ jobs:
           xcode-version: latest-stable
 
       - name: Checkout maplibre-swiftui-dsl-playground
-        uses: actions/checkout@v4
-
-      - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}
-        run: xcodebuild -scheme ${{ matrix.scheme }} test -skipMacroValidation -destination '${{ matrix.destination }}' | xcbeautify && exit ${PIPESTATUS[0]}
-
-  test-macros:
-    runs-on: macos-14
-    strategy:
-      matrix:
-        scheme: [MapLibreSwiftMacros]
-        destination: [
-            # 'platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)',
-            "platform=iOS Simulator,name=iPad (10th generation),OS=16.4",
-            "platform=iOS Simulator,name=iPhone 15,OS=17.2",
-          ]
-    name: test-macros ${{ matrix.destination }}
-
-    steps:
-      - name: Install tools
-        run: brew update && brew upgrade xcbeautify
-
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-
-      - name: Checkout maplibre-swift-macros
         uses: actions/checkout@v4
 
       - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,45 +2,67 @@ name: Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   format-lint:
     runs-on: macos-15
 
     steps:
-    - name: Checkout maplibre-swiftui-dsl-playground
-      uses: actions/checkout@v4
+      - name: Checkout maplibre-swiftui-dsl-playground
+        uses: actions/checkout@v4
 
-    - name: Check format
-      run: swiftformat . --lint
+      - name: Check format
+        run: swiftformat . --lint
 
   test:
     runs-on: macos-15
     strategy:
       matrix:
-        scheme: [
-          MapLibreSwiftUI-Package
-        ]
+        scheme: [MapLibreSwiftUI-Package]
         destination: [
-          # TODO: Add more destinations
-          'platform=iOS Simulator,name=iPhone 16,OS=18.1'
-        ]
+            # TODO: Add more destinations
+            "platform=iOS Simulator,name=iPhone 16,OS=18.1",
+          ]
     name: ${{ matrix.destination }}
 
     steps:
-    - name: Install tools
-      run: brew update && brew upgrade xcbeautify
+      - name: Install tools
+        run: brew update && brew upgrade xcbeautify
 
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
-    - name: Checkout maplibre-swiftui-dsl-playground
-      uses: actions/checkout@v4
+      - name: Checkout maplibre-swiftui-dsl-playground
+        uses: actions/checkout@v4
 
-    - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}
-      run: xcodebuild -scheme ${{ matrix.scheme }} test -skipMacroValidation -destination '${{ matrix.destination }}' | xcbeautify && exit ${PIPESTATUS[0]}
-      
+      - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}
+        run: xcodebuild -scheme ${{ matrix.scheme }} test -skipMacroValidation -destination '${{ matrix.destination }}' | xcbeautify && exit ${PIPESTATUS[0]}
+
+  test-macros:
+    runs-on: macos-14
+    strategy:
+      matrix:
+        scheme: [MapLibreSwiftMacros]
+        destination: [
+            # 'platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)',
+            "platform=iOS Simulator,name=iPad (10th generation),OS=16.4",
+            "platform=iOS Simulator,name=iPhone 15,OS=17.2",
+          ]
+
+    steps:
+      - name: Install tools
+        run: brew update && brew upgrade xcbeautify
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Checkout maplibre-swift-macros
+        uses: actions/checkout@v4
+
+      - name: Test ${{ matrix.scheme }} on ${{ matrix.destination }}
+        run: xcodebuild -scheme ${{ matrix.scheme }} test -skipMacroValidation -destination '${{ matrix.destination }}' | xcbeautify && exit ${PIPESTATUS[0]}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        scheme: [MapLibreSwiftUI-Package]
+        scheme: [MapLibreSwiftUI, MapLibreSwiftDSL]
         destination: [
             # TODO: Add more destinations
             "platform=iOS Simulator,name=iPhone 16,OS=18.1",
           ]
-    name: ${{ matrix.destination }}
+    name: test ${{ matrix.destination }}
 
     steps:
       - name: Install tools
@@ -52,6 +52,7 @@ jobs:
             "platform=iOS Simulator,name=iPad (10th generation),OS=16.4",
             "platform=iOS Simulator,name=iPhone 15,OS=17.2",
           ]
+    name: test-macros ${{ matrix.destination }}
 
     steps:
       - name: Install tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         scheme: [MapLibreSwiftUI-Package]
         destination: [
-            # TODO: Add more destinations
+            # TODO: Add more destinations (snapshot testing is the problem)
             "platform=iOS Simulator,name=iPhone 16,OS=18.1",
             # 'platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)',
-            "platform=iOS Simulator,name=iPad (10th generation),OS=16.4",
-            "platform=iOS Simulator,name=iPhone 15,OS=17.2",
+            # "platform=iOS Simulator,name=iPad (10th generation),OS=16.4",
+            # "platform=iOS Simulator,name=iPhone 15,OS=17.2",
           ]
     name: ${{ matrix.destination }}
 

--- a/.swiftpm/xcode/xcshareddata/xcschemes/MapLibreSwiftUI-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MapLibreSwiftUI-Package.xcscheme
@@ -48,6 +48,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MapLibreSwiftMacros"
+               BuildableName = "MapLibreSwiftMacros"
+               BlueprintName = "MapLibreSwiftMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Moves macro targets into this project. No longer depending on separate https://github.com/stadiamaps/maplibre-swift-macros repo.
+
 ## Version 0.7.0 - 2025-02-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version 0.9.0 - Unreleased
+## Version 0.9.0 - 2025-03-17
 
 - Moves macro targets into this project. No longer depending on separate https://github.com/stadiamaps/maplibre-swift-macros repo.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "38dcbeee72b24bdfa4a2996241d74854484c6c169c780ccbb848c5b91e1f16ce",
+  "originHash" : "a15d9b98afd2dc248ab286d8de4a05772da256d3ca505719a66352f0ae25e0c6",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
@@ -11,21 +11,21 @@
       }
     },
     {
-      "identity" : "maplibre-swift-macros",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stadiamaps/maplibre-swift-macros.git",
-      "state" : {
-        "revision" : "9e27e62dff7fd727aebd0a7c8aa74e7635a5583e",
-        "version" : "0.0.5"
-      }
-    },
-    {
       "identity" : "mockable",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
         "revision" : "e1b311b01c11415099341eee49769185e965ac4c",
         "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "0b80a098d4805a21c412b65f01ffde7b01aab2fa",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a15d9b98afd2dc248ab286d8de4a05772da256d3ca505719a66352f0ae25e0c6",
+  "originHash" : "710725a68bcaf4fadd327f2ee8dde1637a4d7f332050c32685b96f1b9704f4e1",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "e1b311b01c11415099341eee49769185e965ac4c",
-        "version" : "0.2.0"
+        "revision" : "203336d0ccb7ff03a8a03db54a4fa18fc2b0c771",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,13 +19,20 @@ let package = Package(
             name: "MapLibreSwiftDSL",
             targets: ["MapLibreSwiftDSL"]
         ),
+        .library(
+            name: "MapLibreSwiftMacros",
+            targets: ["MapLibreSwiftMacros"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.10.0"),
-        .package(url: "https://github.com/stadiamaps/maplibre-swift-macros.git", from: "0.0.5"),
+        // Macros
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0" ..< "601.0.0"),
         // Testing
         .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.2.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.7"),
+        // Macro Testing
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing", .upToNextMinor(from: "0.6.0")),
     ],
     targets: [
         .target(
@@ -46,7 +53,7 @@ let package = Package(
             dependencies: [
                 .target(name: "InternalUtils"),
                 .product(name: "MapLibre", package: "maplibre-gl-native-distribution"),
-                .product(name: "MapLibreSwiftMacros", package: "maplibre-swift-macros"),
+                "MapLibreSwiftMacros",
             ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
@@ -61,6 +68,19 @@ let package = Package(
                 .enableExperimentalFeature("StrictConcurrency"),
             ]
         ),
+        
+        // MARK: Macro
+        
+        .macro(
+            name: "MapLibreSwiftMacrosImpl",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+            ]
+        ),
+
+        // Library that exposes a macro as part of its API, which is used in client programs.
+        .target(name: "MapLibreSwiftMacros", dependencies: ["MapLibreSwiftMacrosImpl"]),
 
         // MARK: Tests
 
@@ -76,6 +96,17 @@ let package = Package(
             name: "MapLibreSwiftDSLTests",
             dependencies: [
                 "MapLibreSwiftDSL",
+            ]
+        ),
+        
+        // MARK: Macro Tests
+        
+        .testTarget(
+            name: "MapLibreSwiftMacrosTests",
+            dependencies: [
+                "MapLibreSwiftMacrosImpl",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+                .product(name: "MacroTesting", package: "swift-macro-testing"),
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -68,9 +68,9 @@ let package = Package(
                 .enableExperimentalFeature("StrictConcurrency"),
             ]
         ),
-        
+
         // MARK: Macro
-        
+
         .macro(
             name: "MapLibreSwiftMacrosImpl",
             dependencies: [
@@ -98,9 +98,9 @@ let package = Package(
                 "MapLibreSwiftDSL",
             ]
         ),
-        
+
         // MARK: Macro Tests
-        
+
         .testTarget(
             name: "MapLibreSwiftMacrosTests",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         // Macros
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0" ..< "601.0.0"),
         // Testing
-        .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.2.0"),
+        .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.3.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.7"),
         // Macro Testing
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", .upToNextMinor(from: "0.6.0")),

--- a/Sources/MapLibreSwiftMacros/MapLibreSwiftMacros.swift
+++ b/Sources/MapLibreSwiftMacros/MapLibreSwiftMacros.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Adds a stored property and modifiers for an attribute that can be styled using a MapLibre style expression.
+///
+/// Layout and paint properties may be specified using expresisons.
+/// Some expressions may suppeort more types of expressions than others (ex: interpolated).
+/// TODO: Figure out where these edges are.
+/// TODO: Document different types
+@attached(member, names: arbitrary)
+public macro MLNStyleProperty<T>(_ named: String, supportsInterpolation: Bool = false) = #externalMacro(
+    module: "MapLibreSwiftMacrosImpl",
+    type: "MLNStylePropertyMacro"
+)
+
+// NOTE: This version of the macro cannot be more specific, but it is assumed that T: MLNRawRepresentable.
+// This bound should be reintroduced when the packages are re-merged.
+@attached(member, names: arbitrary)
+public macro MLNRawRepresentableStyleProperty<T>(_ named: String) = #externalMacro(
+    module: "MapLibreSwiftMacrosImpl",
+    type: "MLNRawRepresentableStylePropertyMacro"
+)

--- a/Sources/MapLibreSwiftMacrosImpl/MapLibreSwiftMacrosPlugin.swift
+++ b/Sources/MapLibreSwiftMacrosImpl/MapLibreSwiftMacrosPlugin.swift
@@ -1,0 +1,10 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct MapLibreSwiftMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        MLNStylePropertyMacro.self,
+        MLNRawRepresentableStylePropertyMacro.self,
+    ]
+}

--- a/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
+++ b/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
@@ -1,0 +1,132 @@
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+private let allowedKeys = Set(["supportsInterpolation"])
+
+private func generateStyleProperty(for attributes: AttributeSyntax, valueType: TypeSyntax,
+                                   isRawRepresentable: Bool) throws -> [DeclSyntax]
+{
+    guard let args = attributes.arguments, let exprs = args.as(LabeledExprListSyntax.self), exprs.count >= 1,
+          let identifierString = exprs.first?.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue
+    else {
+        fatalError("Compiler bug: this macro did not receive arguments per its public signature.")
+    }
+
+    let flags = Dictionary(uniqueKeysWithValues: exprs.dropFirst().map { expr in
+        guard let key = expr.label?.text, allowedKeys.contains(key),
+              let tokenKind = expr.expression.as(BooleanLiteralExprSyntax.self)?.literal.tokenKind
+        else {
+            fatalError("Compiler bug: this macro did not receive arguments per its public signature.")
+        }
+        return (key, tokenKind == TokenKind.keyword(.true))
+    })
+
+    let identifier = TokenSyntax(stringLiteral: identifierString)
+
+    let varDeclSyntax = DeclSyntax("fileprivate var \(identifier): NSExpression? = nil")
+
+    let constantFuncDecl = try generateFunctionDeclSyntax(
+        identifier: identifier,
+        valueType: valueType,
+        isRawRepresentable: isRawRepresentable
+    )
+
+    let nsExpressionFuncDecl = try FunctionDeclSyntax("public func \(identifier)(expression: NSExpression) -> Self") {
+        "var copy = self"
+        "copy.\(identifier) = expression"
+        "return copy"
+    }
+
+    let getPropFuncDecl =
+        try FunctionDeclSyntax("public func \(identifier)(featurePropertyNamed keyPath: String) -> Self") {
+            "var copy = self"
+            "copy.\(identifier) = NSExpression(forKeyPath: keyPath)"
+            "return copy"
+        }
+
+    guard let constFuncDeclSyntax = DeclSyntax(constantFuncDecl),
+          let getPropFuncDeclSyntax = DeclSyntax(getPropFuncDecl),
+          let nsExpressionFuncDeclSyntax = DeclSyntax(nsExpressionFuncDecl)
+    else {
+        fatalError("SwiftSyntax bug or implementation error: unable to construct DeclSyntax")
+    }
+
+    var extra: [DeclSyntax] = []
+
+    if flags["supportsInterpolation"] == .some(true) {
+        let interpolationFuncDecl =
+            try FunctionDeclSyntax(
+                "public func \(identifier)(interpolatedBy expression: MLNVariableExpression, curveType: MLNExpressionInterpolationMode, parameters: NSExpression?, stops: NSExpression) -> Self"
+            ) {
+                "var copy = self"
+                "copy.\(identifier) = interpolatingExpression(expression: expression, curveType: curveType, parameters: parameters, stops: stops)"
+                "return copy"
+            }
+
+        guard let interpolationFuncDeclSyntax = DeclSyntax(interpolationFuncDecl) else {
+            fatalError("SwiftSyntax bug or implementation error: unable to construct DeclSyntax")
+        }
+
+        extra.append(interpolationFuncDeclSyntax)
+    }
+
+    return [varDeclSyntax, constFuncDeclSyntax, nsExpressionFuncDeclSyntax, getPropFuncDeclSyntax] + extra
+}
+
+private func generateFunctionDeclSyntax(identifier: TokenSyntax, valueType: TypeSyntax,
+                                        isRawRepresentable: Bool) throws -> FunctionDeclSyntax
+{
+    if isRawRepresentable {
+        try FunctionDeclSyntax("public func \(identifier)(_ value: \(valueType)) -> Self") {
+            "var copy = self"
+            "copy.\(identifier) = NSExpression(forConstantValue: value.mlnRawValue.rawValue)"
+            "return copy"
+        }
+    } else {
+        try FunctionDeclSyntax("public func \(identifier)(_ value: \(valueType)) -> Self") {
+            "var copy = self"
+            "copy.\(identifier) = NSExpression(forConstantValue: value)"
+            "return copy"
+        }
+    }
+}
+
+public struct MLNStylePropertyMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf _: some DeclGroupSyntax,
+        in _: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let genericArgument = node
+            .attributeName.as(IdentifierTypeSyntax.self)?
+            .genericArgumentClause?
+            .arguments.first?
+            .argument
+        else {
+            fatalError("Compiler bug: this macro is missing a generic type constraint.")
+        }
+
+        return try generateStyleProperty(for: node, valueType: genericArgument, isRawRepresentable: false)
+    }
+}
+
+public struct MLNRawRepresentableStylePropertyMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf _: some DeclGroupSyntax,
+        in _: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let genericArgument = node
+            .attributeName.as(IdentifierTypeSyntax.self)?
+            .genericArgumentClause?
+            .arguments.first?
+            .argument
+        else {
+            fatalError("Compiler bug: this macro is missing a generic type constraint.")
+        }
+
+        return try generateStyleProperty(for: node, valueType: genericArgument, isRawRepresentable: true)
+    }
+}

--- a/Tests/MapLibreSwiftMacrosTests/MapLibreSwiftMacrosTests.swift
+++ b/Tests/MapLibreSwiftMacrosTests/MapLibreSwiftMacrosTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import MacroTesting
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(MapLibreSwiftMacrosImpl)
+    import MapLibreSwiftMacrosImpl
+#endif
+
+final class ExpressionTests: XCTestCase {
+    override func invokeTest() {
+        #if canImport(MapLibreSwiftMacrosImpl)
+            withMacroTesting(macros: [
+                MLNStylePropertyMacro.self,
+                MLNRawRepresentableStylePropertyMacro.self,
+            ]) {
+                super.invokeTest()
+            }
+        #endif
+    }
+
+    // TODO: Non-enum attachment
+
+    func testMLNStylePropertyValid() throws {
+        #if canImport(MapLibreSwiftMacrosImpl)
+            assertMacro {
+                """
+                @MLNStyleProperty<UIColor>("backgroundColor")
+                struct Layer {
+                }
+                """
+            } expansion: {
+                """
+                struct Layer {
+
+                    fileprivate var backgroundColor: NSExpression? = nil
+
+                    public func backgroundColor(_ value: UIColor) -> Self {
+                        var copy = self
+                        copy.backgroundColor = NSExpression(forConstantValue: value)
+                        return copy
+                    }
+
+                    public func backgroundColor(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = expression
+                        return copy
+                    }
+
+                    public func backgroundColor(featurePropertyNamed keyPath: String) -> Self {
+                        var copy = self
+                        copy.backgroundColor = NSExpression(forKeyPath: keyPath)
+                        return copy
+                    }
+                }
+                """
+            }
+
+            assertMacro {
+                """
+                @MLNStyleProperty<UIColor>("backgroundColor", supportsInterpolation: false)
+                struct Layer {
+                }
+                """
+            } expansion: {
+                """
+                struct Layer {
+
+                    fileprivate var backgroundColor: NSExpression? = nil
+
+                    public func backgroundColor(_ value: UIColor) -> Self {
+                        var copy = self
+                        copy.backgroundColor = NSExpression(forConstantValue: value)
+                        return copy
+                    }
+
+                    public func backgroundColor(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = expression
+                        return copy
+                    }
+
+                    public func backgroundColor(featurePropertyNamed keyPath: String) -> Self {
+                        var copy = self
+                        copy.backgroundColor = NSExpression(forKeyPath: keyPath)
+                        return copy
+                    }
+                }
+                """
+            }
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testMLNStylePropertyValidWithSupportedExpressions() throws {
+        #if canImport(MapLibreSwiftMacrosImpl)
+            assertMacro {
+                """
+                @MLNStyleProperty<UIColor>("backgroundColor", supportsInterpolation: true)
+                struct Layer {
+                }
+                """
+            } expansion: {
+                """
+                struct Layer {
+
+                    fileprivate var backgroundColor: NSExpression? = nil
+
+                    public func backgroundColor(_ value: UIColor) -> Self {
+                        var copy = self
+                        copy.backgroundColor = NSExpression(forConstantValue: value)
+                        return copy
+                    }
+
+                    public func backgroundColor(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = expression
+                        return copy
+                    }
+
+                    public func backgroundColor(featurePropertyNamed keyPath: String) -> Self {
+                        var copy = self
+                        copy.backgroundColor = NSExpression(forKeyPath: keyPath)
+                        return copy
+                    }
+
+                    public func backgroundColor(interpolatedBy expression: MLNVariableExpression, curveType: MLNExpressionInterpolationMode, parameters: NSExpression?, stops: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = interpolatingExpression(expression: expression, curveType: curveType, parameters: parameters, stops: stops)
+                        return copy
+                    }
+                }
+                """
+            }
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testStyleRawExpressionValid() throws {
+        #if canImport(MapLibreSwiftMacrosImpl)
+            assertMacro {
+                """
+                @MLNRawRepresentableStyleProperty<UIColor>("backgroundColor")
+                struct Layer {
+                }
+                """
+            } expansion: {
+                """
+                struct Layer {
+
+                    fileprivate var backgroundColor: NSExpression? = nil
+
+                    public func backgroundColor(_ value: UIColor) -> Self {
+                        var copy = self
+                        copy.backgroundColor = NSExpression(forConstantValue: value.mlnRawValue.rawValue)
+                        return copy
+                    }
+
+                    public func backgroundColor(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = expression
+                        return copy
+                    }
+
+                    public func backgroundColor(featurePropertyNamed keyPath: String) -> Self {
+                        var copy = self
+                        copy.backgroundColor = NSExpression(forKeyPath: keyPath)
+                        return copy
+                    }
+                }
+                """
+            }
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testOptionalArray() throws {
+        // While this property is not actually implemented this way in the DSL,
+        // this test verifies that optional array props work correctly.
+        #if canImport(MapLibreSwiftMacrosImpl)
+            assertMacro {
+                """
+                @MLNStyleProperty<[String]?>("textFontNames", supportsInterpolation: false)
+                struct Layer {
+                }
+                """
+            } expansion: {
+                """
+                struct Layer {
+
+                    fileprivate var textFontNames: NSExpression? = nil
+
+                    public func textFontNames(_ value: [String]?) -> Self {
+                        var copy = self
+                        copy.textFontNames = NSExpression(forConstantValue: value)
+                        return copy
+                    }
+
+                    public func textFontNames(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.textFontNames = expression
+                        return copy
+                    }
+
+                    public func textFontNames(featurePropertyNamed keyPath: String) -> Self {
+                        var copy = self
+                        copy.textFontNames = NSExpression(forKeyPath: keyPath)
+                        return copy
+                    }
+                }
+                """
+            }
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+}


### PR DESCRIPTION
# Issue/Motivation

- Moves macro targets into this project. No longer depending on separate https://github.com/stadiamaps/maplibre-swift-macros repo.
- Integrates macro testing workflow.

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
- [x] Update the CHANGELOG
