### PR TITLE
Add support for MapViewProxy updates in realtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- onMapViewProxyUpdate can now be set up to update in realtime or when animations/scrolling complete (default).
+
 ## Version 0.7.0 - 2025-02-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Version 0.8.0 - 2025-03-17
+
 - onMapViewProxyUpdate can now be set up to update in realtime or when animations/scrolling complete (default).
 
 ## Version 0.7.0 - 2025-02-02

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "38dcbeee72b24bdfa4a2996241d74854484c6c169c780ccbb848c5b91e1f16ce",
+  "originHash" : "2d806e9b1ed4370295b77e0a1e2b6d13694b01c5120a87c8cef3e7b06c17a216",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "3615e3cc81b09b78b58b183660815b0f36107b3b",
-        "version" : "6.10.0"
+        "revision" : "f609802247705d95e852e4e277e597aa88230e2b",
+        "version" : "6.12.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stadiamaps/maplibre-swift-macros.git",
       "state" : {
-        "revision" : "9e27e62dff7fd727aebd0a7c8aa74e7635a5583e",
-        "version" : "0.0.5"
+        "revision" : "92a651a64bdedfea9b55ca365e0101a99a56cf85",
+        "version" : "0.0.6"
       }
     },
     {
@@ -24,8 +24,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "e1b311b01c11415099341eee49769185e965ac4c",
-        "version" : "0.2.0"
+        "revision" : "203336d0ccb7ff03a8a03db54a4fa18fc2b0c771",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {
@@ -33,17 +42,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "2e6a85b73fc14e27d7542165ae73b1a10516ca9a",
-        "version" : "1.17.7"
+        "revision" : "b2d4cb30735f4fbc3a01963a9c658336dd21e9ba",
+        "version" : "1.18.1"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {
@@ -51,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
-        "version" : "1.4.3"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -17,6 +17,7 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
 
     var onStyleLoaded: ((MLNStyle) -> Void)?
     var onViewProxyChanged: ((MapViewProxy) -> Void)?
+    var proxyUpdateMode: ProxyUpdateMode?
 
     var mapViewContentInset: UIEdgeInsets?
 
@@ -50,7 +51,8 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
         MapViewCoordinator<T>(
             parent: self,
             onGesture: { processGesture($0, $1) },
-            onViewProxyChanged: { onViewProxyChanged?($0) }
+            onViewProxyChanged: { onViewProxyChanged?($0) },
+            proxyUpdateMode: proxyUpdateMode ?? .onFinish
         )
     }
 

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -2,7 +2,8 @@ import Foundation
 import MapLibre
 import MapLibreSwiftDSL
 
-public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapViewDelegate {
+public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, @preconcurrency MLNMapViewDelegate {
+    
     // This must be weak, the UIViewRepresentable owns the MLNMapView.
     weak var mapView: MLNMapView?
     var parent: MapView<T>
@@ -21,14 +22,17 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
     var onStyleLoaded: ((MLNStyle) -> Void)?
     var onGesture: (MLNMapView, UIGestureRecognizer) -> Void
     var onViewProxyChanged: (MapViewProxy) -> Void
+    var proxyUpdateMode: ProxyUpdateMode
 
     init(parent: MapView<T>,
          onGesture: @escaping (MLNMapView, UIGestureRecognizer) -> Void,
-         onViewProxyChanged: @escaping (MapViewProxy) -> Void)
+         onViewProxyChanged: @escaping (MapViewProxy) -> Void,
+         proxyUpdateMode: ProxyUpdateMode)
     {
         self.parent = parent
         self.onGesture = onGesture
         self.onViewProxyChanged = onViewProxyChanged
+        self.proxyUpdateMode = proxyUpdateMode
     }
 
     // MARK: Core UIView Functionality
@@ -376,6 +380,8 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
     public func mapView(_ mapView: MLNMapView, regionDidChangeWith reason: MLNCameraChangeReason, animated _: Bool) {
         // TODO: We could put this in regionIsChangingWith if we calculate significant change/debounce.
         MainActor.assumeIsolated {
+            // regionIsChangingWith is not called for the final update, so we need to call updateViewProxy
+            // in both modes here.
             updateViewProxy(mapView: mapView, reason: reason)
 
             guard !suppressCameraUpdatePropagation else {
@@ -383,7 +389,17 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
             }
 
             updateParentCamera(mapView: mapView, reason: reason)
+        
         }
+    }
+    
+    @MainActor
+    public func mapView(_ mapView: MLNMapView, regionIsChangingWith reason: MLNCameraChangeReason) {
+        
+        if proxyUpdateMode == .realtime {
+            updateViewProxy(mapView: mapView, reason: reason)
+        }
+        
     }
 
     // MARK: MapViewProxy
@@ -395,4 +411,13 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
 
         onViewProxyChanged(calculatedViewProxy)
     }
+}
+
+public enum ProxyUpdateMode {
+    /// Causes the `MapViewProxy`to be updated in realtime, including during map view scrolling and animations.
+    /// This will cause multiple updates per seconds. Use only if you really need to run code in realtime while users are
+    /// changing the shown region.
+    case realtime
+    /// Default. Causes `MapViewProxy` to be only be updated when a map view scroll or animation completes.
+    case onFinish
 }

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -3,7 +3,6 @@ import MapLibre
 import MapLibreSwiftDSL
 
 public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, @preconcurrency MLNMapViewDelegate {
-    
     // This must be weak, the UIViewRepresentable owns the MLNMapView.
     weak var mapView: MLNMapView?
     var parent: MapView<T>
@@ -389,17 +388,14 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, @precon
             }
 
             updateParentCamera(mapView: mapView, reason: reason)
-        
         }
     }
-    
+
     @MainActor
     public func mapView(_ mapView: MLNMapView, regionIsChangingWith reason: MLNCameraChangeReason) {
-        
         if proxyUpdateMode == .realtime {
             updateViewProxy(mapView: mapView, reason: reason)
         }
-        
     }
 
     // MARK: MapViewProxy
@@ -415,7 +411,8 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, @precon
 
 public enum ProxyUpdateMode {
     /// Causes the `MapViewProxy`to be updated in realtime, including during map view scrolling and animations.
-    /// This will cause multiple updates per seconds. Use only if you really need to run code in realtime while users are
+    /// This will cause multiple updates per seconds. Use only if you really need to run code in realtime while users
+    /// are
     /// changing the shown region.
     case realtime
     /// Default. Causes `MapViewProxy` to be only be updated when a map view scroll or animation completes.

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -412,8 +412,7 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, @precon
 public enum ProxyUpdateMode {
     /// Causes the `MapViewProxy`to be updated in realtime, including during map view scrolling and animations.
     /// This will cause multiple updates per seconds. Use only if you really need to run code in realtime while users
-    /// are
-    /// changing the shown region.
+    /// are changing the shown region.
     case realtime
     /// Default. Causes `MapViewProxy` to be only be updated when a map view scroll or animation completes.
     case onFinish

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -129,10 +129,26 @@ public extension MapView {
         result.controls = buildControls()
         return result
     }
-
-    func onMapViewProxyUpdate(_ onViewProxyChanged: @escaping (MapViewProxy) -> Void) -> Self {
+    
+    /// The view modifier recieves an instance of `MapViewProxy`, which contains read only information about the current state of the
+    /// `MapView` such as its bounds, center and insets.
+    /// - Parameters:
+    ///   - updateMode: How frequently the `MapViewProxy` is updated. Per default this is set to `.onFinish`, so updates are only
+    ///   sent when the map finally completes updating due to animations or scrolling. Can be set to `.realtime` to recieve updates during
+    ///   the animations and scrolling too.
+    ///   - onViewProxyChanged: The closure containing the `MapViewProxy`. Use this to run code based on the current mapView state.
+    ///
+    /// Example:
+    /// ```swift
+    ///          .onMapViewProxyUpdate() { proxy in
+    ///            print("The map zoom level is: \(proxy.zoomLevel)")
+    ///          }
+    /// ```
+    ///
+    func onMapViewProxyUpdate(updateMode: ProxyUpdateMode = .onFinish, onViewProxyChanged: @escaping (MapViewProxy) -> Void) -> Self {
         var result = self
         result.onViewProxyChanged = onViewProxyChanged
+        result.proxyUpdateMode = updateMode
         return result
     }
 

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -135,10 +135,8 @@ public extension MapView {
     /// `MapView` such as its bounds, center and insets.
     /// - Parameters:
     ///   - updateMode: How frequently the `MapViewProxy` is updated. Per default this is set to `.onFinish`, so updates
-    /// are only
-    ///   sent when the map finally completes updating due to animations or scrolling. Can be set to `.realtime` to
-    /// recieve updates during
-    ///   the animations and scrolling too.
+    /// are only sent when the map finally completes updating due to animations or scrolling. Can be set to `.realtime`
+    /// to recieve updates during the animations and scrolling too.
     ///   - onViewProxyChanged: The closure containing the `MapViewProxy`. Use this to run code based on the current
     /// mapView state.
     ///

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -129,14 +129,18 @@ public extension MapView {
         result.controls = buildControls()
         return result
     }
-    
-    /// The view modifier recieves an instance of `MapViewProxy`, which contains read only information about the current state of the
+
+    /// The view modifier recieves an instance of `MapViewProxy`, which contains read only information about the current
+    /// state of the
     /// `MapView` such as its bounds, center and insets.
     /// - Parameters:
-    ///   - updateMode: How frequently the `MapViewProxy` is updated. Per default this is set to `.onFinish`, so updates are only
-    ///   sent when the map finally completes updating due to animations or scrolling. Can be set to `.realtime` to recieve updates during
+    ///   - updateMode: How frequently the `MapViewProxy` is updated. Per default this is set to `.onFinish`, so updates
+    /// are only
+    ///   sent when the map finally completes updating due to animations or scrolling. Can be set to `.realtime` to
+    /// recieve updates during
     ///   the animations and scrolling too.
-    ///   - onViewProxyChanged: The closure containing the `MapViewProxy`. Use this to run code based on the current mapView state.
+    ///   - onViewProxyChanged: The closure containing the `MapViewProxy`. Use this to run code based on the current
+    /// mapView state.
     ///
     /// Example:
     /// ```swift
@@ -145,7 +149,10 @@ public extension MapView {
     ///          }
     /// ```
     ///
-    func onMapViewProxyUpdate(updateMode: ProxyUpdateMode = .onFinish, onViewProxyChanged: @escaping (MapViewProxy) -> Void) -> Self {
+    func onMapViewProxyUpdate(
+        updateMode: ProxyUpdateMode = .onFinish,
+        onViewProxyChanged: @escaping (MapViewProxy) -> Void
+    ) -> Self {
         var result = self
         result.onViewProxyChanged = onViewProxyChanged
         result.proxyUpdateMode = updateMode

--- a/Tests/MapLibreSwiftUITests/MapViewCoordinator/MapViewCoordinatorCameraTests.swift
+++ b/Tests/MapLibreSwiftUITests/MapViewCoordinator/MapViewCoordinatorCameraTests.swift
@@ -13,11 +13,11 @@ final class MapViewCoordinatorCameraTests: XCTestCase {
         maplibreMapView = MockMLNMapViewCameraUpdating()
         given(maplibreMapView).frame.willReturn(.zero)
         mapView = MapView(styleURL: URL(string: "https://maplibre.org")!)
-        coordinator = MapView.Coordinator(parent: mapView) { _, _ in
+        coordinator = MapView.Coordinator(parent: mapView, onGesture: { _, _ in
             // No action
-        } onViewProxyChanged: { _ in
+        }, onViewProxyChanged: { _ in
             // No action
-        }
+        }, proxyUpdateMode: .onFinish)
     }
 
     @MainActor func testUnchangedCamera() {


### PR DESCRIPTION
# Issue/Motivation

Currently the MapViewProxy is updated via `onMapViewProxyUpdate` when a MapView scroll or animation completes, because it is called via `regionDidChange`, which is only called at the end of all updates. For one of my projects, I need to run some code while the mapView is changed, in other words during scrolling or during map animations, so when `regionIsChanging` is called.

This PR adds an optional parameter to onMapViewProxyUpdate called updateMode which allows devs to pick if they want updates in `.realtime` (multiple times a second while finger is moving or animation is playing) or `.onFinish` (once, when scroll or animation completes. This is the default). 

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [x] Update any documentation for affected APIs
- [x] Update the CHANGELOG
