### PR TITLE
Make release process more sane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       bump_version_scheme:
@@ -17,11 +14,11 @@ on:
         - 'major'
 
 jobs:
-  release-on-push:
+  release:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: rymndhng/release-on-push-action@v0.28.0
         with:
-          bump_version_scheme: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'patch' || inputs.bump_version_scheme }}
+          bump_version_scheme: ${{ inputs.bump_version_scheme }}


### PR DESCRIPTION
# Issue/Motivation

Doesn't auto-release on push to main. This keeps causing confusion if you forget to label a PR. Now releases will be manually dispatched.

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
- [ ] Update the CHANGELOG
