### PR TITLE
Use specific Mockable revision to build with XCode 16.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "710725a68bcaf4fadd327f2ee8dde1637a4d7f332050c32685b96f1b9704f4e1",
+  "originHash" : "ae3cb1b91507a995278c246967b9ed8ab5e461f85a15c75b3a7f584ebefbc70d",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "203336d0ccb7ff03a8a03db54a4fa18fc2b0c771",
-        "version" : "0.3.0"
+        "branch" : "main",
+        "revision" : "68f3ed6c4b62afab27a84425494cb61421a61ac1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         // Macros
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0" ..< "601.0.0"),
         // Testing
-        .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.3.0"),
+        .package(url: "https://github.com/Kolos65/Mockable.git", revision: "68f3ed6c4b62afab27a84425494cb61421a61ac1"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.7"),
         // Macro Testing
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", .upToNextMinor(from: "0.6.0")),


### PR DESCRIPTION
# Issue/Motivation

What issue is this PR targeting? Does not build with Xcode 16.3. See https://github.com/Kolos65/Mockable/commit/68f3ed6c4b62afab27a84425494cb61421a61ac1

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
- [ ] Update the CHANGELOG
