### PR TITLE
Use self.init instead of setting member variables directly.

### DIFF
--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -140,13 +140,13 @@ public extension MapView where T == MLNMapViewController {
         locationManager: MLNLocationManager? = nil,
         @MapViewContentBuilder _ makeMapContent: () -> [StyleLayerDefinition] = { [] }
     ) {
-        makeViewController = {
-            MLNMapViewController()
-        }
-        styleSource = .url(styleURL)
-        _camera = camera
-        userLayers = makeMapContent()
-        self.locationManager = locationManager
+        self.init(
+            makeViewController: MLNMapViewController(),
+            styleURL: styleURL,
+            camera: camera,
+            locationManager: locationManager,
+            makeMapContent
+        )
     }
 }
 


### PR DESCRIPTION
# Issue/Motivation
- This way if the `MapView` initializer should change, it will be a little more obvious for this client when re-building.

What issue is this PR targeting?
None

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
- [ ] Update the CHANGELOG
