### PR TITLE
Add MapActivity to track what MapView is being used for.

### DIFF
--- a/Sources/MapLibreSwiftUI/MLNMapViewController.swift
+++ b/Sources/MapLibreSwiftUI/MLNMapViewController.swift
@@ -7,6 +7,8 @@ public protocol MapViewHostViewController: UIViewController {
 }
 
 public final class MLNMapViewController: UIViewController, MapViewHostViewController {
+    var activity: MapActivity = .standard
+
     @MainActor
     public var mapView: MLNMapView {
         view as! MLNMapView
@@ -14,5 +16,6 @@ public final class MLNMapViewController: UIViewController, MapViewHostViewContro
 
     override public func loadView() {
         view = MLNMapView(frame: .zero)
+        view.tag = activity.rawValue
     }
 }

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -140,13 +140,13 @@ public extension MapView where T == MLNMapViewController {
         locationManager: MLNLocationManager? = nil,
         @MapViewContentBuilder _ makeMapContent: () -> [StyleLayerDefinition] = { [] }
     ) {
-        makeViewController = {
-            MLNMapViewController()
-        }
-        styleSource = .url(styleURL)
-        _camera = camera
-        userLayers = makeMapContent()
-        self.locationManager = locationManager
+        self.init(
+            makeViewController: MLNMapViewController(),
+            styleURL: styleURL,
+            camera: camera,
+            locationManager: locationManager,
+            makeMapContent
+        )
     }
 }
 

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -3,6 +3,14 @@ import MapLibre
 import MapLibreSwiftDSL
 import SwiftUI
 
+/// Identifies the activity this ``MapView`` is being used for. Useful for debugging purposes.
+public enum MapActivity: Int {
+    /// Navigation in a standard window. Default.
+    case standard = 0
+    /// Navigation in a CarPlay template.
+    case carplay = 2025
+}
+
 public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentable {
     public typealias UIViewControllerType = T
     var cameraDisabled: Bool = false
@@ -33,11 +41,14 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
 
     var clusteredLayers: [ClusterLayer]?
 
+    let activity: MapActivity
+
     public init(
         makeViewController: @autoclosure @escaping () -> T,
         styleURL: URL,
         camera: Binding<MapViewCamera> = .constant(.default()),
         locationManager: MLNLocationManager? = nil,
+        activity: MapActivity = .standard,
         @MapViewContentBuilder _ makeMapContent: () -> [StyleLayerDefinition] = { [] }
     ) {
         self.makeViewController = makeViewController
@@ -45,6 +56,7 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
         _camera = camera
         userLayers = makeMapContent()
         self.locationManager = locationManager
+        self.activity = activity
     }
 
     public func makeCoordinator() -> MapViewCoordinator<T> {
@@ -138,13 +150,19 @@ public extension MapView where T == MLNMapViewController {
         styleURL: URL,
         camera: Binding<MapViewCamera> = .constant(.default()),
         locationManager: MLNLocationManager? = nil,
+        activity: MapActivity = .standard,
         @MapViewContentBuilder _ makeMapContent: () -> [StyleLayerDefinition] = { [] }
     ) {
         self.init(
-            makeViewController: MLNMapViewController(),
+            makeViewController: {
+                let vc = MLNMapViewController()
+                vc.activity = activity
+                return vc
+            }(),
             styleURL: styleURL,
             camera: camera,
             locationManager: locationManager,
+            activity: activity,
             makeMapContent
         )
     }


### PR DESCRIPTION
# Issue/Motivation
    - Typically in an application, there is one `MNMapView`. When using CarPlay, there are two. This helps debugging the scenario so that two views can be distinguished from each other when debugging.
    - It sets the `UIView.tag` property of the `MLNMapView` to the enum's rawValue. It also exists in its enumerated type elsewhere.
    
Depends upon #80

What issue is this PR targeting?

None

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
- [ ] Update the CHANGELOG
