### PR TITLE
Support SwiftSyntax v601

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "3ef0341fce60ebda3bd350b1bafb9cebcd8654136f438ae028750da294ee7bf8",
+  "originHash" : "2285e52181b089a5113c1a0565fe0d4a0836365a4d4d552d52396bb19eb77d72",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "3615e3cc81b09b78b58b183660815b0f36107b3b",
-        "version" : "6.10.0"
+        "revision" : "0421942023155bd1c8074438945fbef3a3472a2c",
+        "version" : "6.15.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "68f3ed6c4b62afab27a84425494cb61421a61ac1",
-        "version" : "0.3.1"
+        "revision" : "ee133a696dce312da292b00d0944aafaa808eaca",
+        "version" : "0.4.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "0b80a098d4805a21c412b65f01ffde7b01aab2fa",
-        "version" : "0.6.0"
+        "revision" : "2de00af725ff4c43c9a90d7893835de312653169",
+        "version" : "0.6.3"
       }
     },
     {
@@ -42,17 +42,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "1be8144023c367c5de701a6313ed29a3a10bf59b",
-        "version" : "1.18.3"
+        "revision" : "37230a37e83f1b7023be08e1b1a2603fcb1567fb",
+        "version" : "1.18.4"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
-        "version" : "1.4.3"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", from: "6.10.0"),
         // Macros
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0" ..< "601.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0" ..< "602.0.0"),
         // Testing
         .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.3.1"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.3"),

--- a/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
+++ b/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
@@ -93,6 +93,20 @@ private func generateFunctionDeclSyntax(identifier: TokenSyntax, valueType: Type
     }
 }
 
+#if canImport(SwiftSyntax601)
+// This provides compatibility for the new SwiftSyntax API, returning an empty result if the argument has
+// been parsed as an expression.
+private func generateStyleProperty(for attributes: AttributeSyntax, valueType: GenericArgumentSyntax.Argument,
+                                   isRawRepresentable: Bool) throws -> [DeclSyntax] {
+    switch valueType {
+    case .type(let type):
+        return try generateStyleProperty(for: attributes, valueType: type, isRawRepresentable: isRawRepresentable)
+    default:
+        return []
+    }
+}
+#endif
+
 public struct MLNStylePropertyMacro: MemberMacro {
     public static func expansion(
         of node: AttributeSyntax,


### PR DESCRIPTION
# Issue/Motivation

SwiftSyntax 601.0.1 is the first version of the library that supports the [new preview for prebuilts in SPM](https://forums.swift.org/t/preview-swift-syntax-prebuilts-for-macros/80202). This functionality dramatically improves build times (especially in release configuration) for macro libraries. Now that Mockable 0.4.0 [supports SwiftSyntax v601](https://github.com/Kolos65/Mockable/pull/120), the path is cleared for this library.

## Tasklist

- [x] Update `Package.swift` to support SwiftSyntax up to and including v601.
- [x] Add conditional support for new generic argument API in SwiftSyntax v601.
- [x] Build `MapLibreSwiftUI` in debug/release configurations and benchmark against SwiftSyntax 510.0.3 and 601.0.1.

## Outcome

`MapLibreSwiftUI` builds dramatically faster in both configurations. While it was hard to benchmark builds in Xcode accurately--since `swift build` will fail--I saw times drop from several minutes to archive down to just a matter of seconds. This is consistent with the results I saw on `Mockable` with release builds falling from ~140s down to 9s.

> [!CAUTION]
> `MapLibreSwiftUI` won't build against SwiftSyntax 601.0.0 due to a missing marker module that was [fixed in 601.0.1](https://github.com/swiftlang/swift-syntax/pull/3036).