### PR TITLE
Introduce `line-dash-pattern` on LineStyleLayer

### DIFF
--- a/Sources/MapLibreSwiftDSL/Style Layers/Line.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Line.swift
@@ -7,6 +7,7 @@ import MapLibreSwiftMacros
 @MLNStyleProperty<UIColor>("lineColor", supportsInterpolation: true)
 @MLNRawRepresentableStyleProperty<LineCap>("lineCap")
 @MLNRawRepresentableStyleProperty<LineJoin>("lineJoin")
+@MLNStyleProperty<[Float]>("lineDashPattern")
 @MLNStyleProperty<Float>("lineWidth", supportsInterpolation: true)
 public struct LineStyleLayer: SourceBoundVectorStyleLayerDefinition {
     public let identifier: String
@@ -75,7 +76,7 @@ private struct LineStyleLayerInternal: StyleLayer {
         result.lineCap = definition.lineCap
         result.lineWidth = definition.lineWidth
         result.lineJoin = definition.lineJoin
-
+        result.lineDashPattern = definition.lineDashPattern
         result.predicate = definition.predicate
 
         return result

--- a/Sources/MapLibreSwiftUI/Examples/Polyline.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Polyline.swift
@@ -30,7 +30,8 @@ struct PolylineMapView: View {
 
             // Add an inner (blue) polyline
             LineStyleLayer(identifier: "polyline-inner", source: polylineSource)
-                .lineCap(.round)
+                .lineDashPattern([2.0, 0.5])
+                .lineCap(.butt)
                 .lineJoin(.round)
                 .lineColor(.systemBlue)
                 .lineWidth(interpolatedBy: .zoomLevel,


### PR DESCRIPTION
# Issue/Motivation

This enables `line-dash-pattern` on LineStyleLayer. To showcase it, the Polyline preview is updated:

<img width="469" alt="line-dash-pattern" src="https://github.com/user-attachments/assets/3f2cb3a9-20b7-417b-8058-ef4d22a6d4a6" />


## Tasklist


- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
