### PR TITLE
Feat/mapviewcamera ops update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2285e52181b089a5113c1a0565fe0d4a0836365a4d4d552d52396bb19eb77d72",
+  "originHash" : "1bdf888a9d8e8f39b2b4b42fa6b533420213361c23132a58a6dac5f9d3afd8f7",
   "pins" : [
     {
       "identity" : "maplibre-gl-native-distribution",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "2de00af725ff4c43c9a90d7893835de312653169",
         "version" : "0.6.3"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "bbadd4b853a33fd78c4ae977d17bb2af15eb3f2a",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
         // Macros
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0" ..< "602.0.0"),
         // Testing
+        .package(url: "https://github.com/apple/swift-numerics.git", from: "1.1.0"),
         .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.3.1"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.3"),
         // Macro Testing
@@ -88,6 +89,8 @@ let package = Package(
             name: "MapLibreSwiftUITests",
             dependencies: [
                 "MapLibreSwiftUI",
+                .product(name: "MapLibre", package: "maplibre-gl-native-distribution"),
+                .product(name: "Numerics", package: "swift-numerics"),
                 .product(name: "Mockable", package: "Mockable"),
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ]

--- a/Sources/MapLibreSwiftUI/Extensions/MapViewCamera/MapViewCameraOperations.swift
+++ b/Sources/MapLibreSwiftUI/Extensions/MapViewCamera/MapViewCameraOperations.swift
@@ -2,7 +2,7 @@ import CarPlay
 import Foundation
 import OSLog
 
-fileprivate let logger = Logger(subsystem: "MapLibreSwiftUI", category: "MapViewCameraOperations")
+private let logger = Logger(subsystem: "MapLibreSwiftUI", category: "MapViewCameraOperations")
 
 @MainActor
 public extension MapViewCamera {
@@ -12,7 +12,8 @@ public extension MapViewCamera {
     ///
     /// - Parameters:
     ///  - newZoom: The new zoom value.
-    ///  - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    ///  - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered.
+    /// Allowing zoom from the user's current viewport.
     mutating func setZoom(_ newZoom: Double, proxy: MapViewProxy? = nil) {
         switch state {
         case let .centered(onCoordinate, _, pitch, pitchRange, direction):
@@ -33,7 +34,7 @@ public extension MapViewCamera {
                 logger.debug("Cannot setZoom on a .rect or .showcase camera without a proxy")
                 return
             }
-            
+
             state = .centered(onCoordinate: proxy.centerCoordinate,
                               zoom: newZoom,
                               pitch: MapViewCamera.Defaults.pitch,
@@ -48,7 +49,8 @@ public extension MapViewCamera {
     ///
     /// - Parameters:
     ///   - newZoom: The value to increment the zoom by. Negative decrements the value.
-    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered.
+    /// Allowing zoom from the user's current viewport.
     mutating func incrementZoom(by increment: Double, proxy: MapViewProxy? = nil) {
         switch state {
         case let .centered(onCoordinate, zoom, pitch, pitchRange, direction):
@@ -74,7 +76,7 @@ public extension MapViewCamera {
                 logger.debug("Cannot incrementZoom on a .rect or .showcase camera without a proxy")
                 return
             }
-            
+
             state = .centered(onCoordinate: proxy.centerCoordinate,
                               zoom: proxy.zoomLevel + increment,
                               pitch: MapViewCamera.Defaults.pitch,
@@ -91,7 +93,8 @@ public extension MapViewCamera {
     ///
     /// - Parameters:
     ///   - newPitch: The new pitch value.
-    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered.
+    /// Allowing zoom from the user's current viewport.
     mutating func setPitch(_ newPitch: Double, proxy: MapViewProxy? = nil) {
         switch state {
         case let .centered(onCoordinate, zoom, _, pitchRange, direction):
@@ -112,7 +115,7 @@ public extension MapViewCamera {
                 logger.debug("Cannot setPitch on a .rect or .showcase camera without a proxy")
                 return
             }
-            
+
             state = .centered(onCoordinate: proxy.centerCoordinate,
                               zoom: proxy.zoomLevel,
                               pitch: newPitch,
@@ -122,7 +125,7 @@ public extension MapViewCamera {
 
         lastReasonForChange = .programmatic
     }
-    
+
     /// Set the direction of the camera.
     ///
     /// This will convert a rect and showcase camera to a centered camera while rotating.
@@ -130,64 +133,68 @@ public extension MapViewCamera {
     ///
     /// - Parameters:
     ///   - newDirection: The new camera direction (0 - North to 360)
-    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered.
+    /// Allowing zoom from the user's current viewport.
     mutating func setDirection(_ newDirection: Double, proxy: MapViewProxy? = nil) {
         switch state {
-            
-        case .centered(onCoordinate: let onCoordinate, zoom: let zoom, pitch: let pitch, pitchRange: let pitchRange, _):
-            state = .centered(onCoordinate: onCoordinate, zoom: zoom, pitch: pitch, pitchRange: pitchRange, direction: newDirection)
-        case .trackingUserLocation(zoom: let zoom, pitch: let pitch, pitchRange: let pitchRange, _):
+        case let .centered(onCoordinate: onCoordinate, zoom: zoom, pitch: pitch, pitchRange: pitchRange, _):
+            state = .centered(
+                onCoordinate: onCoordinate,
+                zoom: zoom,
+                pitch: pitch,
+                pitchRange: pitchRange,
+                direction: newDirection
+            )
+        case let .trackingUserLocation(zoom: zoom, pitch: pitch, pitchRange: pitchRange, _):
             state = .trackingUserLocation(zoom: zoom, pitch: pitch, pitchRange: pitchRange, direction: newDirection)
         case .trackingUserLocationWithHeading:
             logger.debug("Cannot setPitch while .trackingUserLocationWithHeading")
-            break
         case .trackingUserLocationWithCourse:
             logger.debug("Cannot setPitch while .trackingUserLocationWithCourse")
-            break
         case .rect, .showcase:
             // This method requires the proxy.
             guard let proxy else {
                 logger.debug("Cannot setDirection on a .rect or .showcase camera without a proxy")
                 return
             }
-            
+
             state = .centered(onCoordinate: proxy.centerCoordinate,
                               zoom: proxy.zoomLevel,
                               pitch: MapViewCamera.Defaults.pitch,
                               pitchRange: .free,
                               direction: newDirection)
         }
-        
+
         lastReasonForChange = .programmatic
     }
-    
+
     // MARK: Car Play
-    
+
     /// Pans the camera for a CarPlay view.
     ///
     /// - Parameters:
     ///   - newPitch: The new pitch value.
-    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered.
+    /// Allowing zoom from the user's current viewport.
     mutating func pan(_ direction: CPMapTemplate.PanDirection, proxy: MapViewProxy? = nil) {
         var currentZoom: Double?
         var currentCenter: CLLocationCoordinate2D?
-        
+
         switch state {
-            
-        case .centered(onCoordinate: let onCoordinate, zoom: let zoom, _, _, _):
+        case let .centered(onCoordinate: onCoordinate, zoom: zoom, _, _, _):
             currentZoom = zoom
             currentCenter = onCoordinate
-        case .trackingUserLocation(zoom: let zoom, _, _, _),
-             .trackingUserLocationWithHeading(zoom: let zoom, _, _),
-             .trackingUserLocationWithCourse(zoom: let zoom, _, _):
+        case let .trackingUserLocation(zoom: zoom, _, _, _),
+             let .trackingUserLocationWithHeading(zoom: zoom, _, _),
+             let .trackingUserLocationWithCourse(zoom: zoom, _, _):
             currentZoom = zoom
         case .rect, .showcase:
             break
         }
-        
+
         let zoom = currentZoom ?? proxy?.zoomLevel ?? MapViewCamera.Defaults.zoom
         let center = currentCenter ?? proxy?.centerCoordinate ?? MapViewCamera.Defaults.coordinate
-        
+
         // Adjust +5 for desired sensitivity
         let sensitivity: Double = 5
         // Pan distance decreases exponentially with zoom level
@@ -195,7 +202,7 @@ public extension MapViewCamera {
         let basePanDistance = 360.0 / pow(2, zoom + sensitivity)
         let latitudeDelta = basePanDistance
         let longitudeDelta = basePanDistance / cos(center.latitude * .pi / 180)
-        
+
         let newCenter: CLLocationCoordinate2D? = switch direction {
         case .down:
             CLLocationCoordinate2D(latitude: center.latitude - latitudeDelta, longitude: center.longitude)
@@ -208,11 +215,11 @@ public extension MapViewCamera {
         default:
             nil
         }
-        
+
         guard let newCenter else {
             return
         }
-        
+
         self = .center(newCenter, zoom: zoom)
         lastReasonForChange = .programmatic
     }

--- a/Sources/MapLibreSwiftUI/Extensions/MapViewCamera/MapViewCameraOperations.swift
+++ b/Sources/MapLibreSwiftUI/Extensions/MapViewCamera/MapViewCameraOperations.swift
@@ -1,12 +1,19 @@
+import CarPlay
 import Foundation
+import OSLog
 
+fileprivate let logger = Logger(subsystem: "MapLibreSwiftUI", category: "MapViewCameraOperations")
+
+@MainActor
 public extension MapViewCamera {
     // MARK: Zoom
 
     /// Set a new zoom for the current camera state.
     ///
-    /// - Parameter newZoom: The new zoom value.
-    mutating func setZoom(_ newZoom: Double) {
+    /// - Parameters:
+    ///  - newZoom: The new zoom value.
+    ///  - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    mutating func setZoom(_ newZoom: Double, proxy: MapViewProxy? = nil) {
         switch state {
         case let .centered(onCoordinate, _, pitch, pitchRange, direction):
             state = .centered(onCoordinate: onCoordinate,
@@ -20,10 +27,18 @@ public extension MapViewCamera {
             state = .trackingUserLocationWithHeading(zoom: newZoom, pitch: pitch, pitchRange: pitchRange)
         case let .trackingUserLocationWithCourse(_, pitch, pitchRange):
             state = .trackingUserLocationWithCourse(zoom: newZoom, pitch: pitch, pitchRange: pitchRange)
-        case .rect:
-            return
-        case .showcase:
-            return
+        case .rect, .showcase:
+            // This method requires the proxy.
+            guard let proxy else {
+                logger.debug("Cannot setZoom on a .rect or .showcase camera without a proxy")
+                return
+            }
+            
+            state = .centered(onCoordinate: proxy.centerCoordinate,
+                              zoom: newZoom,
+                              pitch: MapViewCamera.Defaults.pitch,
+                              pitchRange: .free,
+                              direction: proxy.direction)
         }
 
         lastReasonForChange = .programmatic
@@ -31,8 +46,10 @@ public extension MapViewCamera {
 
     /// Increment the zoom of the current camera state.
     ///
-    /// - Parameter newZoom: The value to increment the zoom by. Negative decrements the value.
-    mutating func incrementZoom(by increment: Double) {
+    /// - Parameters:
+    ///   - newZoom: The value to increment the zoom by. Negative decrements the value.
+    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    mutating func incrementZoom(by increment: Double, proxy: MapViewProxy? = nil) {
         switch state {
         case let .centered(onCoordinate, zoom, pitch, pitchRange, direction):
             state = .centered(onCoordinate: onCoordinate,
@@ -51,10 +68,18 @@ public extension MapViewCamera {
             state = .trackingUserLocationWithHeading(zoom: zoom + increment, pitch: pitch, pitchRange: pitchRange)
         case let .trackingUserLocationWithCourse(zoom, pitch, pitchRange):
             state = .trackingUserLocationWithCourse(zoom: zoom + increment, pitch: pitch, pitchRange: pitchRange)
-        case .rect:
-            return
-        case .showcase:
-            return
+        case .rect, .showcase:
+            // This method requires the proxy.
+            guard let proxy else {
+                logger.debug("Cannot incrementZoom on a .rect or .showcase camera without a proxy")
+                return
+            }
+            
+            state = .centered(onCoordinate: proxy.centerCoordinate,
+                              zoom: proxy.zoomLevel + increment,
+                              pitch: MapViewCamera.Defaults.pitch,
+                              pitchRange: .free,
+                              direction: proxy.direction)
         }
 
         lastReasonForChange = .programmatic
@@ -64,8 +89,10 @@ public extension MapViewCamera {
 
     /// Set a new pitch for the current camera state.
     ///
-    /// - Parameter newPitch: The new pitch value.
-    mutating func setPitch(_ newPitch: Double) {
+    /// - Parameters:
+    ///   - newPitch: The new pitch value.
+    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    mutating func setPitch(_ newPitch: Double, proxy: MapViewProxy? = nil) {
         switch state {
         case let .centered(onCoordinate, zoom, _, pitchRange, direction):
             state = .centered(onCoordinate: onCoordinate,
@@ -79,14 +106,114 @@ public extension MapViewCamera {
             state = .trackingUserLocationWithHeading(zoom: zoom, pitch: newPitch, pitchRange: pitchRange)
         case let .trackingUserLocationWithCourse(zoom, _, pitchRange):
             state = .trackingUserLocationWithCourse(zoom: zoom, pitch: newPitch, pitchRange: pitchRange)
-        case .rect:
-            return
-        case .showcase:
-            return
+        case .rect, .showcase:
+            // This method requires the proxy.
+            guard let proxy else {
+                logger.debug("Cannot setPitch on a .rect or .showcase camera without a proxy")
+                return
+            }
+            
+            state = .centered(onCoordinate: proxy.centerCoordinate,
+                              zoom: proxy.zoomLevel,
+                              pitch: newPitch,
+                              pitchRange: .free,
+                              direction: proxy.direction)
         }
 
         lastReasonForChange = .programmatic
     }
-
-    // TODO: Add direction set
+    
+    /// Set the direction of the camera.
+    ///
+    /// This will convert a rect and showcase camera to a centered camera while rotating.
+    /// Tracking user location with heading and course will ignore this behavior.
+    ///
+    /// - Parameters:
+    ///   - newDirection: The new camera direction (0 - North to 360)
+    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    mutating func setDirection(_ newDirection: Double, proxy: MapViewProxy? = nil) {
+        switch state {
+            
+        case .centered(onCoordinate: let onCoordinate, zoom: let zoom, pitch: let pitch, pitchRange: let pitchRange, _):
+            state = .centered(onCoordinate: onCoordinate, zoom: zoom, pitch: pitch, pitchRange: pitchRange, direction: newDirection)
+        case .trackingUserLocation(zoom: let zoom, pitch: let pitch, pitchRange: let pitchRange, _):
+            state = .trackingUserLocation(zoom: zoom, pitch: pitch, pitchRange: pitchRange, direction: newDirection)
+        case .trackingUserLocationWithHeading:
+            logger.debug("Cannot setPitch while .trackingUserLocationWithHeading")
+            break
+        case .trackingUserLocationWithCourse:
+            logger.debug("Cannot setPitch while .trackingUserLocationWithCourse")
+            break
+        case .rect, .showcase:
+            // This method requires the proxy.
+            guard let proxy else {
+                logger.debug("Cannot setDirection on a .rect or .showcase camera without a proxy")
+                return
+            }
+            
+            state = .centered(onCoordinate: proxy.centerCoordinate,
+                              zoom: proxy.zoomLevel,
+                              pitch: MapViewCamera.Defaults.pitch,
+                              pitchRange: .free,
+                              direction: newDirection)
+        }
+        
+        lastReasonForChange = .programmatic
+    }
+    
+    // MARK: Car Play
+    
+    /// Pans the camera for a CarPlay view.
+    ///
+    /// - Parameters:
+    ///   - newPitch: The new pitch value.
+    ///   - proxy: An optional map view proxy, this allows the camera to convert from .rect/.showcase to centered. Allowing zoom from the user's current viewport.
+    mutating func pan(_ direction: CPMapTemplate.PanDirection, proxy: MapViewProxy? = nil) {
+        var currentZoom: Double?
+        var currentCenter: CLLocationCoordinate2D?
+        
+        switch state {
+            
+        case .centered(onCoordinate: let onCoordinate, zoom: let zoom, _, _, _):
+            currentZoom = zoom
+            currentCenter = onCoordinate
+        case .trackingUserLocation(zoom: let zoom, _, _, _),
+             .trackingUserLocationWithHeading(zoom: let zoom, _, _),
+             .trackingUserLocationWithCourse(zoom: let zoom, _, _):
+            currentZoom = zoom
+        case .rect, .showcase:
+            break
+        }
+        
+        let zoom = currentZoom ?? proxy?.zoomLevel ?? MapViewCamera.Defaults.zoom
+        let center = currentCenter ?? proxy?.centerCoordinate ?? MapViewCamera.Defaults.coordinate
+        
+        // Adjust +5 for desired sensitivity
+        let sensitivity: Double = 5
+        // Pan distance decreases exponentially with zoom level
+        // At zoom 0: ~5.6 degrees, at zoom 10: ~0.0055 degrees, at zoom 20: ~0.000005 degrees
+        let basePanDistance = 360.0 / pow(2, zoom + sensitivity)
+        let latitudeDelta = basePanDistance
+        let longitudeDelta = basePanDistance / cos(center.latitude * .pi / 180)
+        
+        let newCenter: CLLocationCoordinate2D? = switch direction {
+        case .down:
+            CLLocationCoordinate2D(latitude: center.latitude - latitudeDelta, longitude: center.longitude)
+        case .up:
+            CLLocationCoordinate2D(latitude: center.latitude + latitudeDelta, longitude: center.longitude)
+        case .left:
+            CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude - longitudeDelta)
+        case .right:
+            CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude + longitudeDelta)
+        default:
+            nil
+        }
+        
+        guard let newCenter else {
+            return
+        }
+        
+        self = .center(newCenter, zoom: zoom)
+        lastReasonForChange = .programmatic
+    }
 }

--- a/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
@@ -5,7 +5,8 @@ import MapLibre
 /// The SwiftUI MapViewCamera.
 ///
 /// This manages the camera state within the MapView.
-public struct MapViewCamera: Hashable, Equatable, Sendable, CustomStringConvertible {
+@MainActor
+public struct MapViewCamera: Hashable, Equatable, Sendable, @preconcurrency CustomStringConvertible {
     public enum Defaults {
         public static let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
         public static let zoom: Double = 10

--- a/Sources/MapLibreSwiftUI/Models/MapViewProxy.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapViewProxy.swift
@@ -18,46 +18,82 @@ import MapLibre
 @MainActor
 public struct MapViewProxy: Hashable, Equatable {
     /// The current center coordinate of the MapView
-    public var centerCoordinate: CLLocationCoordinate2D {
-        mapView.centerCoordinate
-    }
+    public let centerCoordinate: CLLocationCoordinate2D
 
     /// The current zoom value of the MapView
-    public var zoomLevel: Double {
-        mapView.zoomLevel
-    }
+    public let zoomLevel: Double
 
     /// The current compass direction of the MapView
-    public var direction: CLLocationDirection {
-        mapView.direction
-    }
+    public let direction: CLLocationDirection
 
-    public var visibleCoordinateBounds: MLNCoordinateBounds {
-        mapView.visibleCoordinateBounds
-    }
+    /// The visible coordinate bounds of the MapView
+    public let visibleCoordinateBounds: MLNCoordinateBounds
 
-    public var mapViewSize: CGSize {
-        mapView.frame.size
-    }
+    /// The size of the MapView
+    public let mapViewSize: CGSize
 
-    public var contentInset: UIEdgeInsets {
-        mapView.contentInset
-    }
+    /// The content inset of the MapView
+    public let contentInset: UIEdgeInsets
 
     /// The reason the view port was changed.
     public let lastReasonForChange: CameraChangeReason?
 
-    private let mapView: MLNMapView
+    /// The underlying MLNMapView (only used for functions that require it)
+    private let mapView: MLNMapView?
 
-    public func convert(_ coordinate: CLLocationCoordinate2D, toPointTo: UIView?) -> CGPoint {
-        mapView.convert(coordinate, toPointTo: toPointTo)
+    /// Convert a coordinate to a point in the MapView
+    /// - Parameters:
+    ///   - coordinate: The coordinate to convert
+    ///   - toPointTo: The view to convert the point to (usually nil for the MapView itself)
+    /// - Returns: The CGPoint representation of the coordinate
+    public func convert(_ coordinate: CLLocationCoordinate2D, toPointTo: UIView?) -> CGPoint? {
+        guard let mapView else {
+            return nil
+        }
+        return mapView.convert(coordinate, toPointTo: toPointTo)
     }
 
-    public init(mapView: MLNMapView,
-                lastReasonForChange: CameraChangeReason?)
-    {
-        self.mapView = mapView
+    /// Initialize with an MLNMapView (captures current values)
+    /// - Parameters:
+    ///   - mapView: The MLNMapView to capture values from
+    ///   - lastReasonForChange: The reason for the last camera change
+    public init(mapView: MLNMapView, lastReasonForChange: CameraChangeReason?) {
+        self.centerCoordinate = mapView.centerCoordinate
+        self.zoomLevel = mapView.zoomLevel
+        self.direction = mapView.direction
+        self.visibleCoordinateBounds = mapView.visibleCoordinateBounds
+        self.mapViewSize = mapView.frame.size
+        self.contentInset = mapView.contentInset
         self.lastReasonForChange = lastReasonForChange
+        self.mapView = mapView
+    }
+
+    /// Initialize with explicit values (useful for testing)
+    /// - Parameters:
+    ///   - centerCoordinate: The center coordinate
+    ///   - zoomLevel: The zoom level
+    ///   - direction: The compass direction
+    ///   - visibleCoordinateBounds: The visible coordinate bounds
+    ///   - mapViewSize: The size of the map view
+    ///   - contentInset: The content inset
+    ///   - lastReasonForChange: The reason for the last camera change
+    public init(
+        centerCoordinate: CLLocationCoordinate2D,
+        zoomLevel: Double,
+        direction: CLLocationDirection,
+        visibleCoordinateBounds: MLNCoordinateBounds,
+        mapViewSize: CGSize = CGSize(width: 320, height: 568),
+        contentInset: UIEdgeInsets = .zero,
+        lastReasonForChange: CameraChangeReason? = nil
+    ) {
+        self.centerCoordinate = centerCoordinate
+        self.zoomLevel = zoomLevel
+        self.direction = direction
+        self.visibleCoordinateBounds = visibleCoordinateBounds
+        self.mapViewSize = mapViewSize
+        self.contentInset = contentInset
+        self.lastReasonForChange = lastReasonForChange
+        self.mapView = nil
     }
 }
 

--- a/Sources/MapLibreSwiftUI/Models/MapViewProxy.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapViewProxy.swift
@@ -58,12 +58,12 @@ public struct MapViewProxy: Hashable, Equatable {
     ///   - mapView: The MLNMapView to capture values from
     ///   - lastReasonForChange: The reason for the last camera change
     public init(mapView: MLNMapView, lastReasonForChange: CameraChangeReason?) {
-        self.centerCoordinate = mapView.centerCoordinate
-        self.zoomLevel = mapView.zoomLevel
-        self.direction = mapView.direction
-        self.visibleCoordinateBounds = mapView.visibleCoordinateBounds
-        self.mapViewSize = mapView.frame.size
-        self.contentInset = mapView.contentInset
+        centerCoordinate = mapView.centerCoordinate
+        zoomLevel = mapView.zoomLevel
+        direction = mapView.direction
+        visibleCoordinateBounds = mapView.visibleCoordinateBounds
+        mapViewSize = mapView.frame.size
+        contentInset = mapView.contentInset
         self.lastReasonForChange = lastReasonForChange
         self.mapView = mapView
     }
@@ -93,7 +93,7 @@ public struct MapViewProxy: Hashable, Equatable {
         self.mapViewSize = mapViewSize
         self.contentInset = contentInset
         self.lastReasonForChange = lastReasonForChange
-        self.mapView = nil
+        mapView = nil
     }
 }
 

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraOperationTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraOperationTests.swift
@@ -1,22 +1,21 @@
-import Testing
+import CarPlay
+import CoreLocation
+import MapLibre
 import Numerics
 import SnapshotTesting
-import MapLibre
-import CoreLocation
-import CarPlay
+import Testing
 @testable import MapLibreSwiftUI
 
 @MainActor
 struct MapViewCameraOperationTests {
-    
     // MARK: - Test Data
-    
+
     let testCoordinate = CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)
     let testZoom: Double = 15.0
     let testPitch: Double = 30.0
     let testDirection: Double = 90.0
     let testPitchRange: CameraPitchRange = .freeWithinRange(minimum: 0, maximum: 60)
-    
+
     var mockProxy: MapViewProxy {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
@@ -32,9 +31,9 @@ struct MapViewCameraOperationTests {
             lastReasonForChange: .programmatic
         )
     }
-    
+
     // MARK: - setZoom Tests
-    
+
     @Test func setZoom_centeredCamera_updatesZoomCorrectly() async throws {
         var camera = MapViewCamera.center(
             testCoordinate,
@@ -43,13 +42,13 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: testDirection
         )
-        
+
         camera.setZoom(testZoom)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }
-    
+
     @Test func setZoom_trackingUserLocationCamera_updatesZoomCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocation(
             zoom: 10.0,
@@ -57,52 +56,52 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: testDirection
         )
-        
+
         camera.setZoom(testZoom)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }
-    
+
     @Test func setZoom_trackingUserLocationWithHeadingCamera_updatesZoomCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocationWithHeading(
             zoom: 10.0,
             pitch: testPitch,
             pitchRange: testPitchRange
         )
-        
+
         camera.setZoom(testZoom)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }
-    
+
     @Test func setZoom_trackingUserLocationWithCourseCamera_updatesZoomCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocationWithCourse(
             zoom: 10.0,
             pitch: testPitch,
             pitchRange: testPitchRange
         )
-        
+
         camera.setZoom(testZoom)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }
-    
+
     @Test func setZoom_rectCamera_withProxy_convertsToCenteredCamera() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
             ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
         )
         var camera = MapViewCamera.boundingBox(bounds)
-        
+
         camera.setZoom(testZoom, proxy: mockProxy)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }
-    
+
     @Test func setZoom_rectCamera_withoutProxy_doesNothing() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
@@ -110,15 +109,15 @@ struct MapViewCameraOperationTests {
         )
         var camera = MapViewCamera.boundingBox(bounds)
         let originalState = camera.state
-        
+
         camera.setZoom(testZoom)
-        
+
         #expect(camera.state == originalState)
         #expect(camera.lastReasonForChange == .programmatic) // Still set from constructor
     }
-    
+
     // MARK: - incrementZoom Tests
-    
+
     @Test func incrementZoom_centeredCamera_incrementsZoomCorrectly() async throws {
         var camera = MapViewCamera.center(
             testCoordinate,
@@ -127,21 +126,21 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: testDirection
         )
-        
+
         camera.incrementZoom(by: 2.5)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }
-    
+
     @Test func incrementZoom_negativeIncrement_decrementsZoom() async throws {
         var camera = MapViewCamera.center(testCoordinate, zoom: 10.0)
-        
+
         camera.incrementZoom(by: -3.0)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func incrementZoom_trackingUserLocationCamera_incrementsZoomCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocation(
             zoom: 8.0,
@@ -149,48 +148,48 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: testDirection
         )
-        
+
         camera.incrementZoom(by: 5.0)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func incrementZoom_trackingUserLocationWithHeadingCamera_incrementsZoomCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocationWithHeading(
             zoom: 12.0,
             pitch: testPitch,
             pitchRange: testPitchRange
         )
-        
+
         camera.incrementZoom(by: -2.0)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func incrementZoom_trackingUserLocationWithCourseCamera_incrementsZoomCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocationWithCourse(
             zoom: 14.0,
             pitch: testPitch,
             pitchRange: testPitchRange
         )
-        
+
         camera.incrementZoom(by: 1.5)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func incrementZoom_rectCamera_withProxy_convertsToCenteredCamera() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
             ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
         )
         var camera = MapViewCamera.boundingBox(bounds)
-        
+
         camera.incrementZoom(by: 3.0, proxy: mockProxy)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func incrementZoom_rectCamera_withoutProxy_doesNothing() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
@@ -198,14 +197,14 @@ struct MapViewCameraOperationTests {
         )
         var camera = MapViewCamera.boundingBox(bounds)
         let originalState = camera.state
-        
+
         camera.incrementZoom(by: 3.0)
-        
+
         #expect(camera.state == originalState)
     }
-    
+
     // MARK: - setPitch Tests
-    
+
     @Test func setPitch_centeredCamera_updatesPitchCorrectly() async throws {
         var camera = MapViewCamera.center(
             testCoordinate,
@@ -214,13 +213,13 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: testDirection
         )
-        
+
         camera.setPitch(testPitch)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }
-    
+
     @Test func setPitch_trackingUserLocationCamera_updatesPitchCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocation(
             zoom: testZoom,
@@ -228,48 +227,48 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: testDirection
         )
-        
+
         camera.setPitch(testPitch)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func setPitch_trackingUserLocationWithHeadingCamera_updatesPitchCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocationWithHeading(
             zoom: testZoom,
             pitch: 0.0,
             pitchRange: testPitchRange
         )
-        
+
         camera.setPitch(testPitch)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func setPitch_trackingUserLocationWithCourseCamera_updatesPitchCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocationWithCourse(
             zoom: testZoom,
             pitch: 0.0,
             pitchRange: testPitchRange
         )
-        
+
         camera.setPitch(testPitch)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func setPitch_rectCamera_withProxy_convertsToCenteredCamera() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
             ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
         )
         var camera = MapViewCamera.boundingBox(bounds)
-        
+
         camera.setPitch(testPitch, proxy: mockProxy)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func setPitch_rectCamera_withoutProxy_doesNothing() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
@@ -277,14 +276,14 @@ struct MapViewCameraOperationTests {
         )
         var camera = MapViewCamera.boundingBox(bounds)
         let originalState = camera.state
-        
+
         camera.setPitch(testPitch)
-        
+
         #expect(camera.state == originalState)
     }
-    
+
     // MARK: - setDirection Tests
-    
+
     @Test func setDirection_centeredCamera_updatesDirectionCorrectly() async throws {
         var camera = MapViewCamera.center(
             testCoordinate,
@@ -293,13 +292,13 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: 0.0
         )
-        
+
         camera.setDirection(testDirection)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }
-    
+
     @Test func setDirection_trackingUserLocationCamera_updatesDirectionCorrectly() async throws {
         var camera = MapViewCamera.trackUserLocation(
             zoom: testZoom,
@@ -307,12 +306,12 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: 0.0
         )
-        
+
         camera.setDirection(testDirection)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func setDirection_trackingUserLocationWithHeadingCamera_ignoresDirection() async throws {
         var camera = MapViewCamera.trackUserLocationWithHeading(
             zoom: testZoom,
@@ -320,13 +319,13 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange
         )
         let originalState = camera.state
-        
+
         camera.setDirection(testDirection)
-        
+
         // Should remain unchanged for heading tracking
         #expect(camera.state == originalState)
     }
-    
+
     @Test func setDirection_trackingUserLocationWithCourseCamera_ignoresDirection() async throws {
         var camera = MapViewCamera.trackUserLocationWithCourse(
             zoom: testZoom,
@@ -334,25 +333,25 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange
         )
         let originalState = camera.state
-        
+
         camera.setDirection(testDirection)
-        
+
         // Should remain unchanged for course tracking
         #expect(camera.state == originalState)
     }
-    
+
     @Test func setDirection_rectCamera_withProxy_convertsToCenteredCamera() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
             ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
         )
         var camera = MapViewCamera.boundingBox(bounds)
-        
+
         camera.setDirection(testDirection, proxy: mockProxy)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
     }
-    
+
     @Test func setDirection_rectCamera_withoutProxy_doesNothing() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
@@ -360,77 +359,77 @@ struct MapViewCameraOperationTests {
         )
         var camera = MapViewCamera.boundingBox(bounds)
         let originalState = camera.state
-        
+
         camera.setDirection(testDirection)
-        
+
         #expect(camera.state == originalState)
     }
-    
+
     // MARK: - CarPlay Pan Tests
-    
+
     @Test func pan_centeredCamera_upDirection_pansCameraUp() async throws {
         var camera = MapViewCamera.center(testCoordinate, zoom: testZoom)
-        
+
         camera.pan(.up)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Verify the camera moved north (increased latitude)
         if case let .centered(onCoordinate: newCoordinate, _, _, _, _) = camera.state {
             #expect(newCoordinate.latitude > testCoordinate.latitude)
             #expect(newCoordinate.longitude == testCoordinate.longitude)
         }
     }
-    
+
     @Test func pan_centeredCamera_downDirection_pansCameraDown() async throws {
         var camera = MapViewCamera.center(testCoordinate, zoom: testZoom)
-        
+
         camera.pan(.down)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Verify the camera moved south (decreased latitude)
         if case let .centered(onCoordinate: newCoordinate, _, _, _, _) = camera.state {
             #expect(newCoordinate.latitude < testCoordinate.latitude)
             #expect(newCoordinate.longitude == testCoordinate.longitude)
         }
     }
-    
+
     @Test func pan_centeredCamera_leftDirection_pansCameraLeft() async throws {
         var camera = MapViewCamera.center(testCoordinate, zoom: testZoom)
-        
+
         camera.pan(.left)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Verify the camera moved west (decreased longitude)
         if case let .centered(onCoordinate: newCoordinate, _, _, _, _) = camera.state {
             #expect(newCoordinate.latitude == testCoordinate.latitude)
             #expect(newCoordinate.longitude < testCoordinate.longitude)
         }
     }
-    
+
     @Test func pan_centeredCamera_rightDirection_pansCameraRight() async throws {
         var camera = MapViewCamera.center(testCoordinate, zoom: testZoom)
-        
+
         camera.pan(.right)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Verify the camera moved east (increased longitude)
         if case let .centered(onCoordinate: newCoordinate, _, _, _, _) = camera.state {
             #expect(newCoordinate.latitude == testCoordinate.latitude)
             #expect(newCoordinate.longitude > testCoordinate.longitude)
         }
     }
-    
+
     @Test func pan_trackingUserLocationCamera_convertsToCenteredCamera() async throws {
         var camera = MapViewCamera.trackUserLocation(zoom: testZoom)
-        
+
         camera.pan(.up, proxy: mockProxy)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Should convert to centered camera
         if case .centered = camera.state {
             // Expected behavior
@@ -438,14 +437,14 @@ struct MapViewCameraOperationTests {
             Issue.record("Expected camera to convert to centered state")
         }
     }
-    
+
     @Test func pan_trackingUserLocationWithHeadingCamera_convertsToCenteredCamera() async throws {
         var camera = MapViewCamera.trackUserLocationWithHeading(zoom: testZoom)
-        
+
         camera.pan(.down, proxy: mockProxy)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Should convert to centered camera
         if case .centered = camera.state {
             // Expected behavior
@@ -453,14 +452,14 @@ struct MapViewCameraOperationTests {
             Issue.record("Expected camera to convert to centered state")
         }
     }
-    
+
     @Test func pan_trackingUserLocationWithCourseCamera_convertsToCenteredCamera() async throws {
         var camera = MapViewCamera.trackUserLocationWithCourse(zoom: testZoom)
-        
+
         camera.pan(.left, proxy: mockProxy)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Should convert to centered camera
         if case .centered = camera.state {
             // Expected behavior
@@ -468,18 +467,18 @@ struct MapViewCameraOperationTests {
             Issue.record("Expected camera to convert to centered state")
         }
     }
-    
+
     @Test func pan_rectCamera_withProxy_convertsToCenteredCamera() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
             ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
         )
         var camera = MapViewCamera.boundingBox(bounds)
-        
+
         camera.pan(.right, proxy: mockProxy)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Should convert to centered camera
         if case .centered = camera.state {
             // Expected behavior
@@ -487,56 +486,63 @@ struct MapViewCameraOperationTests {
             Issue.record("Expected camera to convert to centered state")
         }
     }
-    
+
     @Test func pan_rectCamera_withoutProxy_usesDefaults() async throws {
         let bounds = MLNCoordinateBounds(
             sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
             ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
         )
         var camera = MapViewCamera.boundingBox(bounds)
-        
+
         camera.pan(.up)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
-        
+
         // Should convert to centered camera using defaults
         if case let .centered(onCoordinate: coordinate, zoom: zoom, _, _, _) = camera.state {
-            #expect(coordinate.latitude.isApproximatelyEqual(to: MapViewCamera.Defaults.coordinate.latitude, absoluteTolerance: 0.05))
-            #expect(coordinate.longitude.isApproximatelyEqual(to: MapViewCamera.Defaults.coordinate.longitude, absoluteTolerance: 0.05))
+            #expect(coordinate.latitude.isApproximatelyEqual(
+                to: MapViewCamera.Defaults.coordinate.latitude,
+                absoluteTolerance: 0.05
+            ))
+            #expect(coordinate.longitude.isApproximatelyEqual(
+                to: MapViewCamera.Defaults.coordinate.longitude,
+                absoluteTolerance: 0.05
+            ))
             #expect(zoom == MapViewCamera.Defaults.zoom)
         } else {
             Issue.record("Expected camera to convert to centered state with defaults")
         }
     }
-    
+
     @Test func pan_zoomSensitivity_higherZoomMeansSmallerMovement() async throws {
         let highZoomCamera = MapViewCamera.center(testCoordinate, zoom: 20.0)
         let lowZoomCamera = MapViewCamera.center(testCoordinate, zoom: 5.0)
-        
+
         var highZoomCameraCopy = highZoomCamera
         var lowZoomCameraCopy = lowZoomCamera
-        
+
         highZoomCameraCopy.pan(.up)
         lowZoomCameraCopy.pan(.up)
-        
+
         // Get the new coordinates
         guard case let .centered(onCoordinate: highZoomCoord, _, _, _, _) = highZoomCameraCopy.state,
-              case let .centered(onCoordinate: lowZoomCoord, _, _, _, _) = lowZoomCameraCopy.state else {
+              case let .centered(onCoordinate: lowZoomCoord, _, _, _, _) = lowZoomCameraCopy.state
+        else {
             Issue.record("Expected centered camera states")
             return
         }
-        
+
         let highZoomDelta = highZoomCoord.latitude - testCoordinate.latitude
         let lowZoomDelta = lowZoomCoord.latitude - testCoordinate.latitude
-        
+
         // Higher zoom should result in smaller movement
         #expect(highZoomDelta < lowZoomDelta)
         #expect(highZoomDelta > 0) // Still moved north
-        #expect(lowZoomDelta > 0)  // Still moved north
+        #expect(lowZoomDelta > 0) // Still moved north
     }
-    
+
     // MARK: - Edge Cases and Error Conditions
-    
+
     @Test func allOperations_preserveOtherStateProperties() async throws {
         let initialCamera = MapViewCamera.center(
             testCoordinate,
@@ -545,29 +551,29 @@ struct MapViewCameraOperationTests {
             pitchRange: testPitchRange,
             direction: testDirection
         )
-        
+
         // Test that each operation preserves unmodified properties
         var zoomTestCamera = initialCamera
         zoomTestCamera.setZoom(20.0)
-        
+
         var pitchTestCamera = initialCamera
         pitchTestCamera.setPitch(45.0)
-        
+
         var directionTestCamera = initialCamera
         directionTestCamera.setDirection(180.0)
-        
+
         assertSnapshot(of: zoomTestCamera.state, as: .dump, named: "zoom-modified")
         assertSnapshot(of: pitchTestCamera.state, as: .dump, named: "pitch-modified")
         assertSnapshot(of: directionTestCamera.state, as: .dump, named: "direction-modified")
     }
-    
+
     @Test func operations_onDefaultCamera_workCorrectly() async throws {
         var camera = MapViewCamera.default()
-        
+
         camera.setZoom(12.0)
         camera.setPitch(25.0)
         camera.setDirection(270.0)
-        
+
         assertSnapshot(of: camera.state, as: .dump)
         #expect(camera.lastReasonForChange == .programmatic)
     }

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraOperationTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraOperationTests.swift
@@ -1,0 +1,574 @@
+import Testing
+import Numerics
+import SnapshotTesting
+import MapLibre
+import CoreLocation
+import CarPlay
+@testable import MapLibreSwiftUI
+
+@MainActor
+struct MapViewCameraOperationTests {
+    
+    // MARK: - Test Data
+    
+    let testCoordinate = CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)
+    let testZoom: Double = 15.0
+    let testPitch: Double = 30.0
+    let testDirection: Double = 90.0
+    let testPitchRange: CameraPitchRange = .freeWithinRange(minimum: 0, maximum: 60)
+    
+    var mockProxy: MapViewProxy {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        return MapViewProxy(
+            centerCoordinate: testCoordinate,
+            zoomLevel: testZoom,
+            direction: testDirection,
+            visibleCoordinateBounds: bounds,
+            mapViewSize: CGSize(width: 320, height: 568),
+            contentInset: .zero,
+            lastReasonForChange: .programmatic
+        )
+    }
+    
+    // MARK: - setZoom Tests
+    
+    @Test func setZoom_centeredCamera_updatesZoomCorrectly() async throws {
+        var camera = MapViewCamera.center(
+            testCoordinate,
+            zoom: 10.0,
+            pitch: testPitch,
+            pitchRange: testPitchRange,
+            direction: testDirection
+        )
+        
+        camera.setZoom(testZoom)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+    
+    @Test func setZoom_trackingUserLocationCamera_updatesZoomCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocation(
+            zoom: 10.0,
+            pitch: testPitch,
+            pitchRange: testPitchRange,
+            direction: testDirection
+        )
+        
+        camera.setZoom(testZoom)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+    
+    @Test func setZoom_trackingUserLocationWithHeadingCamera_updatesZoomCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocationWithHeading(
+            zoom: 10.0,
+            pitch: testPitch,
+            pitchRange: testPitchRange
+        )
+        
+        camera.setZoom(testZoom)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+    
+    @Test func setZoom_trackingUserLocationWithCourseCamera_updatesZoomCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocationWithCourse(
+            zoom: 10.0,
+            pitch: testPitch,
+            pitchRange: testPitchRange
+        )
+        
+        camera.setZoom(testZoom)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+    
+    @Test func setZoom_rectCamera_withProxy_convertsToCenteredCamera() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        
+        camera.setZoom(testZoom, proxy: mockProxy)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+    
+    @Test func setZoom_rectCamera_withoutProxy_doesNothing() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        let originalState = camera.state
+        
+        camera.setZoom(testZoom)
+        
+        #expect(camera.state == originalState)
+        #expect(camera.lastReasonForChange == .programmatic) // Still set from constructor
+    }
+    
+    // MARK: - incrementZoom Tests
+    
+    @Test func incrementZoom_centeredCamera_incrementsZoomCorrectly() async throws {
+        var camera = MapViewCamera.center(
+            testCoordinate,
+            zoom: 10.0,
+            pitch: testPitch,
+            pitchRange: testPitchRange,
+            direction: testDirection
+        )
+        
+        camera.incrementZoom(by: 2.5)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+    
+    @Test func incrementZoom_negativeIncrement_decrementsZoom() async throws {
+        var camera = MapViewCamera.center(testCoordinate, zoom: 10.0)
+        
+        camera.incrementZoom(by: -3.0)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func incrementZoom_trackingUserLocationCamera_incrementsZoomCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocation(
+            zoom: 8.0,
+            pitch: testPitch,
+            pitchRange: testPitchRange,
+            direction: testDirection
+        )
+        
+        camera.incrementZoom(by: 5.0)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func incrementZoom_trackingUserLocationWithHeadingCamera_incrementsZoomCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocationWithHeading(
+            zoom: 12.0,
+            pitch: testPitch,
+            pitchRange: testPitchRange
+        )
+        
+        camera.incrementZoom(by: -2.0)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func incrementZoom_trackingUserLocationWithCourseCamera_incrementsZoomCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocationWithCourse(
+            zoom: 14.0,
+            pitch: testPitch,
+            pitchRange: testPitchRange
+        )
+        
+        camera.incrementZoom(by: 1.5)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func incrementZoom_rectCamera_withProxy_convertsToCenteredCamera() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        
+        camera.incrementZoom(by: 3.0, proxy: mockProxy)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func incrementZoom_rectCamera_withoutProxy_doesNothing() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        let originalState = camera.state
+        
+        camera.incrementZoom(by: 3.0)
+        
+        #expect(camera.state == originalState)
+    }
+    
+    // MARK: - setPitch Tests
+    
+    @Test func setPitch_centeredCamera_updatesPitchCorrectly() async throws {
+        var camera = MapViewCamera.center(
+            testCoordinate,
+            zoom: testZoom,
+            pitch: 0.0,
+            pitchRange: testPitchRange,
+            direction: testDirection
+        )
+        
+        camera.setPitch(testPitch)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+    
+    @Test func setPitch_trackingUserLocationCamera_updatesPitchCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocation(
+            zoom: testZoom,
+            pitch: 0.0,
+            pitchRange: testPitchRange,
+            direction: testDirection
+        )
+        
+        camera.setPitch(testPitch)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func setPitch_trackingUserLocationWithHeadingCamera_updatesPitchCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocationWithHeading(
+            zoom: testZoom,
+            pitch: 0.0,
+            pitchRange: testPitchRange
+        )
+        
+        camera.setPitch(testPitch)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func setPitch_trackingUserLocationWithCourseCamera_updatesPitchCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocationWithCourse(
+            zoom: testZoom,
+            pitch: 0.0,
+            pitchRange: testPitchRange
+        )
+        
+        camera.setPitch(testPitch)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func setPitch_rectCamera_withProxy_convertsToCenteredCamera() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        
+        camera.setPitch(testPitch, proxy: mockProxy)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func setPitch_rectCamera_withoutProxy_doesNothing() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        let originalState = camera.state
+        
+        camera.setPitch(testPitch)
+        
+        #expect(camera.state == originalState)
+    }
+    
+    // MARK: - setDirection Tests
+    
+    @Test func setDirection_centeredCamera_updatesDirectionCorrectly() async throws {
+        var camera = MapViewCamera.center(
+            testCoordinate,
+            zoom: testZoom,
+            pitch: testPitch,
+            pitchRange: testPitchRange,
+            direction: 0.0
+        )
+        
+        camera.setDirection(testDirection)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+    
+    @Test func setDirection_trackingUserLocationCamera_updatesDirectionCorrectly() async throws {
+        var camera = MapViewCamera.trackUserLocation(
+            zoom: testZoom,
+            pitch: testPitch,
+            pitchRange: testPitchRange,
+            direction: 0.0
+        )
+        
+        camera.setDirection(testDirection)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func setDirection_trackingUserLocationWithHeadingCamera_ignoresDirection() async throws {
+        var camera = MapViewCamera.trackUserLocationWithHeading(
+            zoom: testZoom,
+            pitch: testPitch,
+            pitchRange: testPitchRange
+        )
+        let originalState = camera.state
+        
+        camera.setDirection(testDirection)
+        
+        // Should remain unchanged for heading tracking
+        #expect(camera.state == originalState)
+    }
+    
+    @Test func setDirection_trackingUserLocationWithCourseCamera_ignoresDirection() async throws {
+        var camera = MapViewCamera.trackUserLocationWithCourse(
+            zoom: testZoom,
+            pitch: testPitch,
+            pitchRange: testPitchRange
+        )
+        let originalState = camera.state
+        
+        camera.setDirection(testDirection)
+        
+        // Should remain unchanged for course tracking
+        #expect(camera.state == originalState)
+    }
+    
+    @Test func setDirection_rectCamera_withProxy_convertsToCenteredCamera() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        
+        camera.setDirection(testDirection, proxy: mockProxy)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+    }
+    
+    @Test func setDirection_rectCamera_withoutProxy_doesNothing() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        let originalState = camera.state
+        
+        camera.setDirection(testDirection)
+        
+        #expect(camera.state == originalState)
+    }
+    
+    // MARK: - CarPlay Pan Tests
+    
+    @Test func pan_centeredCamera_upDirection_pansCameraUp() async throws {
+        var camera = MapViewCamera.center(testCoordinate, zoom: testZoom)
+        
+        camera.pan(.up)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Verify the camera moved north (increased latitude)
+        if case let .centered(onCoordinate: newCoordinate, _, _, _, _) = camera.state {
+            #expect(newCoordinate.latitude > testCoordinate.latitude)
+            #expect(newCoordinate.longitude == testCoordinate.longitude)
+        }
+    }
+    
+    @Test func pan_centeredCamera_downDirection_pansCameraDown() async throws {
+        var camera = MapViewCamera.center(testCoordinate, zoom: testZoom)
+        
+        camera.pan(.down)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Verify the camera moved south (decreased latitude)
+        if case let .centered(onCoordinate: newCoordinate, _, _, _, _) = camera.state {
+            #expect(newCoordinate.latitude < testCoordinate.latitude)
+            #expect(newCoordinate.longitude == testCoordinate.longitude)
+        }
+    }
+    
+    @Test func pan_centeredCamera_leftDirection_pansCameraLeft() async throws {
+        var camera = MapViewCamera.center(testCoordinate, zoom: testZoom)
+        
+        camera.pan(.left)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Verify the camera moved west (decreased longitude)
+        if case let .centered(onCoordinate: newCoordinate, _, _, _, _) = camera.state {
+            #expect(newCoordinate.latitude == testCoordinate.latitude)
+            #expect(newCoordinate.longitude < testCoordinate.longitude)
+        }
+    }
+    
+    @Test func pan_centeredCamera_rightDirection_pansCameraRight() async throws {
+        var camera = MapViewCamera.center(testCoordinate, zoom: testZoom)
+        
+        camera.pan(.right)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Verify the camera moved east (increased longitude)
+        if case let .centered(onCoordinate: newCoordinate, _, _, _, _) = camera.state {
+            #expect(newCoordinate.latitude == testCoordinate.latitude)
+            #expect(newCoordinate.longitude > testCoordinate.longitude)
+        }
+    }
+    
+    @Test func pan_trackingUserLocationCamera_convertsToCenteredCamera() async throws {
+        var camera = MapViewCamera.trackUserLocation(zoom: testZoom)
+        
+        camera.pan(.up, proxy: mockProxy)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Should convert to centered camera
+        if case .centered = camera.state {
+            // Expected behavior
+        } else {
+            Issue.record("Expected camera to convert to centered state")
+        }
+    }
+    
+    @Test func pan_trackingUserLocationWithHeadingCamera_convertsToCenteredCamera() async throws {
+        var camera = MapViewCamera.trackUserLocationWithHeading(zoom: testZoom)
+        
+        camera.pan(.down, proxy: mockProxy)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Should convert to centered camera
+        if case .centered = camera.state {
+            // Expected behavior
+        } else {
+            Issue.record("Expected camera to convert to centered state")
+        }
+    }
+    
+    @Test func pan_trackingUserLocationWithCourseCamera_convertsToCenteredCamera() async throws {
+        var camera = MapViewCamera.trackUserLocationWithCourse(zoom: testZoom)
+        
+        camera.pan(.left, proxy: mockProxy)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Should convert to centered camera
+        if case .centered = camera.state {
+            // Expected behavior
+        } else {
+            Issue.record("Expected camera to convert to centered state")
+        }
+    }
+    
+    @Test func pan_rectCamera_withProxy_convertsToCenteredCamera() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        
+        camera.pan(.right, proxy: mockProxy)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Should convert to centered camera
+        if case .centered = camera.state {
+            // Expected behavior
+        } else {
+            Issue.record("Expected camera to convert to centered state")
+        }
+    }
+    
+    @Test func pan_rectCamera_withoutProxy_usesDefaults() async throws {
+        let bounds = MLNCoordinateBounds(
+            sw: CLLocationCoordinate2D(latitude: 37.0, longitude: -123.0),
+            ne: CLLocationCoordinate2D(latitude: 38.0, longitude: -122.0)
+        )
+        var camera = MapViewCamera.boundingBox(bounds)
+        
+        camera.pan(.up)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        
+        // Should convert to centered camera using defaults
+        if case let .centered(onCoordinate: coordinate, zoom: zoom, _, _, _) = camera.state {
+            #expect(coordinate.latitude.isApproximatelyEqual(to: MapViewCamera.Defaults.coordinate.latitude, absoluteTolerance: 0.05))
+            #expect(coordinate.longitude.isApproximatelyEqual(to: MapViewCamera.Defaults.coordinate.longitude, absoluteTolerance: 0.05))
+            #expect(zoom == MapViewCamera.Defaults.zoom)
+        } else {
+            Issue.record("Expected camera to convert to centered state with defaults")
+        }
+    }
+    
+    @Test func pan_zoomSensitivity_higherZoomMeansSmallerMovement() async throws {
+        let highZoomCamera = MapViewCamera.center(testCoordinate, zoom: 20.0)
+        let lowZoomCamera = MapViewCamera.center(testCoordinate, zoom: 5.0)
+        
+        var highZoomCameraCopy = highZoomCamera
+        var lowZoomCameraCopy = lowZoomCamera
+        
+        highZoomCameraCopy.pan(.up)
+        lowZoomCameraCopy.pan(.up)
+        
+        // Get the new coordinates
+        guard case let .centered(onCoordinate: highZoomCoord, _, _, _, _) = highZoomCameraCopy.state,
+              case let .centered(onCoordinate: lowZoomCoord, _, _, _, _) = lowZoomCameraCopy.state else {
+            Issue.record("Expected centered camera states")
+            return
+        }
+        
+        let highZoomDelta = highZoomCoord.latitude - testCoordinate.latitude
+        let lowZoomDelta = lowZoomCoord.latitude - testCoordinate.latitude
+        
+        // Higher zoom should result in smaller movement
+        #expect(highZoomDelta < lowZoomDelta)
+        #expect(highZoomDelta > 0) // Still moved north
+        #expect(lowZoomDelta > 0)  // Still moved north
+    }
+    
+    // MARK: - Edge Cases and Error Conditions
+    
+    @Test func allOperations_preserveOtherStateProperties() async throws {
+        let initialCamera = MapViewCamera.center(
+            testCoordinate,
+            zoom: testZoom,
+            pitch: testPitch,
+            pitchRange: testPitchRange,
+            direction: testDirection
+        )
+        
+        // Test that each operation preserves unmodified properties
+        var zoomTestCamera = initialCamera
+        zoomTestCamera.setZoom(20.0)
+        
+        var pitchTestCamera = initialCamera
+        pitchTestCamera.setPitch(45.0)
+        
+        var directionTestCamera = initialCamera
+        directionTestCamera.setDirection(180.0)
+        
+        assertSnapshot(of: zoomTestCamera.state, as: .dump, named: "zoom-modified")
+        assertSnapshot(of: pitchTestCamera.state, as: .dump, named: "pitch-modified")
+        assertSnapshot(of: directionTestCamera.state, as: .dump, named: "direction-modified")
+    }
+    
+    @Test func operations_onDefaultCamera_workCorrectly() async throws {
+        var camera = MapViewCamera.default()
+        
+        camera.setZoom(12.0)
+        camera.setPitch(25.0)
+        camera.setDirection(270.0)
+        
+        assertSnapshot(of: camera.state, as: .dump)
+        #expect(camera.lastReasonForChange == .programmatic)
+    }
+}

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraTests.swift
@@ -4,6 +4,7 @@ import SnapshotTesting
 import XCTest
 @testable import MapLibreSwiftUI
 
+@MainActor
 final class MapViewCameraTests: XCTestCase {
     func testCenterCamera() {
         let camera = MapViewCamera.center(

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/allOperations_preserveOtherStateProperties.direction-modified.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/allOperations_preserveOtherStateProperties.direction-modified.txt
@@ -1,0 +1,12 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 180.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/allOperations_preserveOtherStateProperties.pitch-modified.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/allOperations_preserveOtherStateProperties.pitch-modified.txt
@@ -1,0 +1,12 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 45.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/allOperations_preserveOtherStateProperties.zoom-modified.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/allOperations_preserveOtherStateProperties.zoom-modified.txt
@@ -1,0 +1,12 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 20.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_centeredCamera_incrementsZoomCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_centeredCamera_incrementsZoomCorrectly.1.txt
@@ -1,0 +1,12 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 12.5
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_negativeIncrement_decrementsZoom.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_negativeIncrement_decrementsZoom.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 7.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_rectCamera_withProxy_convertsToCenteredCamera.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_rectCamera_withProxy_convertsToCenteredCamera.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 18.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_trackingUserLocationCamera_incrementsZoomCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_trackingUserLocationCamera_incrementsZoomCorrectly.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ trackingUserLocation: (4 elements)
+    - zoom: 13.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_trackingUserLocationWithCourseCamera_incrementsZoomCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_trackingUserLocationWithCourseCamera_incrementsZoomCorrectly.1.txt
@@ -1,0 +1,8 @@
+▿ CameraState
+  ▿ trackingUserLocationWithCourse: (3 elements)
+    - zoom: 15.5
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_trackingUserLocationWithHeadingCamera_incrementsZoomCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/incrementZoom_trackingUserLocationWithHeadingCamera_incrementsZoomCorrectly.1.txt
@@ -1,0 +1,8 @@
+▿ CameraState
+  ▿ trackingUserLocationWithHeading: (3 elements)
+    - zoom: 10.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/operations_onDefaultCamera_workCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/operations_onDefaultCamera_workCorrectly.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 0.0
+      - longitude: 0.0
+    - zoom: 12.0
+    - pitch: 25.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 270.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_centeredCamera_downDirection_pansCameraDown.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_centeredCamera_downDirection_pansCameraDown.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.774556677246096
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_centeredCamera_leftDirection_pansCameraLeft.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_centeredCamera_leftDirection_pansCameraLeft.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.41983435295266
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_centeredCamera_rightDirection_pansCameraRight.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_centeredCamera_rightDirection_pansCameraRight.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.41896564704733
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_centeredCamera_upDirection_pansCameraUp.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_centeredCamera_upDirection_pansCameraUp.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.77524332275391
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_rectCamera_withProxy_convertsToCenteredCamera.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_rectCamera_withProxy_convertsToCenteredCamera.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.41896564704733
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_rectCamera_withoutProxy_usesDefaults.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_rectCamera_withoutProxy_usesDefaults.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 0.010986328125
+      - longitude: 0.0
+    - zoom: 10.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_trackingUserLocationCamera_convertsToCenteredCamera.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_trackingUserLocationCamera_convertsToCenteredCamera.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.77524332275391
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_trackingUserLocationWithCourseCamera_convertsToCenteredCamera.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_trackingUserLocationWithCourseCamera_convertsToCenteredCamera.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.41983435295266
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_trackingUserLocationWithHeadingCamera_convertsToCenteredCamera.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/pan_trackingUserLocationWithHeadingCamera_convertsToCenteredCamera.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.774556677246096
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 0.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setDirection_centeredCamera_updatesDirectionCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setDirection_centeredCamera_updatesDirectionCorrectly.1.txt
@@ -1,0 +1,12 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setDirection_rectCamera_withProxy_convertsToCenteredCamera.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setDirection_rectCamera_withProxy_convertsToCenteredCamera.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setDirection_trackingUserLocationCamera_updatesDirectionCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setDirection_trackingUserLocationCamera_updatesDirectionCorrectly.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ trackingUserLocation: (4 elements)
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_centeredCamera_updatesPitchCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_centeredCamera_updatesPitchCorrectly.1.txt
@@ -1,0 +1,12 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_rectCamera_withProxy_convertsToCenteredCamera.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_rectCamera_withProxy_convertsToCenteredCamera.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 30.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_trackingUserLocationCamera_updatesPitchCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_trackingUserLocationCamera_updatesPitchCorrectly.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ trackingUserLocation: (4 elements)
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_trackingUserLocationWithCourseCamera_updatesPitchCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_trackingUserLocationWithCourseCamera_updatesPitchCorrectly.1.txt
@@ -1,0 +1,8 @@
+▿ CameraState
+  ▿ trackingUserLocationWithCourse: (3 elements)
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_trackingUserLocationWithHeadingCamera_updatesPitchCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setPitch_trackingUserLocationWithHeadingCamera_updatesPitchCorrectly.1.txt
@@ -1,0 +1,8 @@
+▿ CameraState
+  ▿ trackingUserLocationWithHeading: (3 elements)
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_centeredCamera_updatesZoomCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_centeredCamera_updatesZoomCorrectly.1.txt
@@ -1,0 +1,12 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_rectCamera_withProxy_convertsToCenteredCamera.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_rectCamera_withProxy_convertsToCenteredCamera.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ centered: (5 elements)
+    ▿ onCoordinate: CLLocationCoordinate2D
+      - latitude: 37.7749
+      - longitude: -122.4194
+    - zoom: 15.0
+    - pitch: 0.0
+    - pitchRange: CameraPitchRange.free
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_trackingUserLocationCamera_updatesZoomCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_trackingUserLocationCamera_updatesZoomCorrectly.1.txt
@@ -1,0 +1,9 @@
+▿ CameraState
+  ▿ trackingUserLocation: (4 elements)
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0
+    - direction: 90.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_trackingUserLocationWithCourseCamera_updatesZoomCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_trackingUserLocationWithCourseCamera_updatesZoomCorrectly.1.txt
@@ -1,0 +1,8 @@
+▿ CameraState
+  ▿ trackingUserLocationWithCourse: (3 elements)
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_trackingUserLocationWithHeadingCamera_updatesZoomCorrectly.1.txt
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/__Snapshots__/MapViewCameraOperationTests/setZoom_trackingUserLocationWithHeadingCamera_updatesZoomCorrectly.1.txt
@@ -1,0 +1,8 @@
+▿ CameraState
+  ▿ trackingUserLocationWithHeading: (3 elements)
+    - zoom: 15.0
+    - pitch: 30.0
+    ▿ pitchRange: CameraPitchRange
+      ▿ freeWithinRange: (2 elements)
+        - minimum: 0.0
+        - maximum: 60.0


### PR DESCRIPTION
# Issue/Motivation

- Adds `setDirection` for MapViewCamera
- Adds `pan` MapViewCamera. For use with CarPlay directions.
- Introduces optional `MapViewProxy` to camera operations to allow changing camera from a 'stuck' rect and showcase camera.
- Removes getters for `MapViewProxy` to enable testing. @hactar 

## Tasklist

- [x] Include tests (if applicable) and examples (new or edits)
- [ ] ~~If there are any visual changes as a result, include before/after screenshots and/or videos~~
- [ ] Add #fixes with the issue number that this PR addresses
- [x] Update any documentation for affected APIs
