### PR TITLE
Fix LineStyleLayerInternal.sourceLayerIdentifier not being set.

### DIFF
--- a/Sources/MapLibreSwiftDSL/Style Layers/Line.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Line.swift
@@ -78,6 +78,7 @@ private struct LineStyleLayerInternal: StyleLayer {
         result.lineJoin = definition.lineJoin
         result.lineDashPattern = definition.lineDashPattern
         result.predicate = definition.predicate
+        result.sourceLayerIdentifier = definition.sourceLayerIdentifier
 
         return result
     }


### PR DESCRIPTION
# Issue/Motivation

Fixes #105 

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [x] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
